### PR TITLE
Add InnoSetup installer

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -1,0 +1,19 @@
+[Setup]
+AppName=NecroBot
+AppVersion=1.0
+DefaultDirName={pf}\NecroBot
+DefaultGroupName=NecroBot
+UninstallDisplayIcon={app}\NecroBot.exe
+Compression=lzma2
+SolidCompression=yes
+OutputDir=.
+OutputBaseFilename=NecroBotSetup
+
+[Files]
+Source: "*"; Excludes: "temp,Logs,installer.iss,NecroBotSetup.exe"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs      
+
+[Icons]
+Name: "{group}\NecroBot"; Filename: "{app}\NecroBot.exe"
+
+[Dirs]
+Name: "{app}\"; Permissions: everyone-modify


### PR DESCRIPTION
### Description
In addition to Release.zip, perhaps we could have an installer release to add start icons, uninstall, and related. Attached is a trivial inno setup (common windows foss installer) install script. I don't know how release.zip is made, but this script could be run on that result.

### Testing
1. Compile script from 4.0 extracted Release.zip
2. Execute shortcut from start menu
Verified Logs and temp did not copy over. Ensured app ran (very briefly).

### Note
Pardon I don't know more about process of how release.zip is made, but I'm all ears. Was crazy fast for me to write it but I can make tweaks too! :)