### PR TITLE
Add Moves to TransferFilter

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using POGOProtos.Enums;
 using POGOProtos.Inventory.Item;
+using POGOProtos.Settings.Master.Item;
 
 #endregion
 
@@ -46,16 +47,19 @@ namespace PoGo.NecroBot.Logic
         {
         }
 
-        public TransferFilter(int keepMinCp, float keepMinIvPercentage, int keepMinDuplicatePokemon)
+        public TransferFilter(int keepMinCp, float keepMinIvPercentage, int keepMinDuplicatePokemon, 
+            List<PokemonMove> moves = null)
         {
             KeepMinCp = keepMinCp;
             KeepMinIvPercentage = keepMinIvPercentage;
             KeepMinDuplicatePokemon = keepMinDuplicatePokemon;
+            Moves = moves ?? new List<PokemonMove>();
         }
 
         public int KeepMinCp { get; set; }
         public float KeepMinIvPercentage { get; set; }
         public int KeepMinDuplicatePokemon { get; set; }
+        public List<PokemonMove> Moves { get; set; }
     }
 
     public interface ILogicSettings

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -13,6 +13,7 @@ using POGOProtos.Inventory.Item;
 using System.ComponentModel;
 using System.Reflection;
 using System.Collections;
+using System.Linq;
 
 #endregion
 
@@ -440,6 +441,12 @@ namespace PoGo.NecroBot.Logic
                     jsonSettings.DefaultValueHandling = DefaultValueHandling.Populate;
 
                     settings = JsonConvert.DeserializeObject<GlobalSettings>(input, jsonSettings);
+                    
+                    //This makes sure that existing config files dont get null values which lead to an exception
+                    foreach (var filter in settings.PokemonsTransferFilter.Where(x => x.Value.Moves == null))
+                    {
+                        filter.Value.Moves = new List<PokemonMove>();
+                    }
 
                     // One day we might be able to better do this so its automatic
                     /*

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -7,6 +7,7 @@ using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
+using POGOProtos.Enums;
 
 #endregion
 
@@ -30,11 +31,14 @@ namespace PoGo.NecroBot.Logic.Tasks
             foreach (var duplicatePokemon in duplicatePokemons)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                var pokemonTransferFilter = session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId);
 
                 if (duplicatePokemon.Cp >=
-                    session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinCp ||
+                    pokemonTransferFilter.KeepMinCp ||
                     PokemonInfo.CalculatePokemonPerfection(duplicatePokemon) >
-                    session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinIvPercentage)
+                    pokemonTransferFilter.KeepMinIvPercentage ||
+                    pokemonTransferFilter.Moves.Contains(duplicatePokemon.Move1) ||
+                    pokemonTransferFilter.Moves.Contains(duplicatePokemon.Move2))
                 {
                     continue;
                 }


### PR DESCRIPTION
Based on the idea of #1753 I added a new property "Moves" to the TransferFilter. If a duplicate Pokemon has one of these moves it won't be transferred.

If you accept this PR, the wiki should mention that the first move always has the postfix "Fast". Otherwise it can't be deserialized.