### PR TITLE
Use Ultraball logic and thresholds for Razz Berries instead of hard coded values.

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -46,17 +46,17 @@ namespace PoGo.NecroBot.Logic.Tasks
                     return;
                 }
 
-                var isLowProbability = probability < 0.35;
+                var isLowProbability = probability < session.LogicSettings.UseUltraBallBelowCatchProbability;
                 var isHighCp = encounter != null &&
                                (encounter is EncounterResponse
                                    ? encounter.WildPokemon?.PokemonData?.Cp
-                                   : encounter.PokemonData?.Cp) > 400;
+                                   : encounter.PokemonData?.Cp) > session.LogicSettings.UseUltraBallAboveCp;
                 var isHighPerfection =
                     PokemonInfo.CalculatePokemonPerfection(encounter is EncounterResponse
                         ? encounter.WildPokemon?.PokemonData
-                        : encounter?.PokemonData) >= session.LogicSettings.KeepMinIvPercentage;
+                        : encounter?.PokemonData) >= session.LogicSettings.UseUltraBallAboveIv;
 
-                if ((isLowProbability && isHighCp) || isHighPerfection)
+                if (isLowProbability || isHighCp || isHighPerfection)
                 {
                     await
                         UseBerry(session,


### PR DESCRIPTION
Don't waste Razz Berries all the time because of using hard coded thresholds.
Use same logic and thresholds for Razz Berries as for Ultraballs.

This change fixes 
#1622 #1691 #1710 #1790 