### PR TITLE
Set Console.Title on start

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -23,6 +23,7 @@ namespace PoGo.NecroBot.CLI
         {
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionEventHandler;
             Console.SetWindowSize(165, 30);
+            Console.Title = "NecroBot starting";
             Console.CancelKeyPress += (sender, eArgs) =>
             {
                 QuitEvent.Set();


### PR DESCRIPTION
When it's waiting a long time to login, it just shows path to the exe, now it'll show NecroBot starting.