### PR TITLE
[issues/1884] BUG: removed fixed console window width

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -22,7 +22,6 @@ namespace PoGo.NecroBot.CLI
         private static void Main(string[] args)
         {
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionEventHandler;
-            Console.SetWindowSize(165, 30);
             Console.CancelKeyPress += (sender, eArgs) =>
             {
                 QuitEvent.Set();


### PR DESCRIPTION
#1884 Removed fixed console width making application unbuildable on smaller screens (console window should be set in default settings of the console itself on  user's computer)