### PR TITLE
Update .gitmodules to use directly original FeroxRev api and not forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "FeroxRev"]
 	path = FeroxRev
-	url = https://github.com/NecronomiconCoding/NecroBot-Rocket-API
+	url = https://github.com/FeroxRev/Pokemon-Go-Rocket-API
 	branch = master


### PR DESCRIPTION
Update .gitmodules to use directly original FeroxRev api and not forks