### PR TITLE
Add new option 'AlwaysEvolveWithLuckyEggWhenMinPokemonAmountOccurs' w…

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -108,6 +108,7 @@ namespace PoGo.NecroBot.Logic
         string GpxFile { get; }
         bool UseLuckyEggsWhileEvolving { get; }
         int UseLuckyEggsMinPokemonAmount { get; }
+        bool AlwaysEvolveWithLuckyEggWhenMinPokemonAmountOccurs { get; }
         bool EvolveAllPokemonAboveIv { get; }
         float EvolveAboveIvValue { get; }
         bool DumpPokemonStats { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -194,6 +194,8 @@ namespace PoGo.NecroBot.Logic
         public bool UseLuckyEggConstantly;
         [DefaultValue(30)]
         public int UseLuckyEggsMinPokemonAmount;
+        [DefaultValue(true)]
+        public Boolean AlwaysEvolveWithLuckyEggWhenMinPokemonAmountOccurs;
         [DefaultValue(false)]
         public bool UseLuckyEggsWhileEvolving;
         [DefaultValue(false)]
@@ -749,6 +751,7 @@ namespace PoGo.NecroBot.Logic
         public bool UseGpxPathing => _settings.UseGpxPathing;
         public bool UseLuckyEggsWhileEvolving => _settings.UseLuckyEggsWhileEvolving;
         public int UseLuckyEggsMinPokemonAmount => _settings.UseLuckyEggsMinPokemonAmount;
+        public bool AlwaysEvolveWithLuckyEggWhenMinPokemonAmountOccurs => _settings.AlwaysEvolveWithLuckyEggWhenMinPokemonAmountOccurs;
         public bool EvolveAllPokemonAboveIv => _settings.EvolveAllPokemonAboveIv;
         public float EvolveAboveIvValue => _settings.EvolveAboveIvValue;
         public bool RenamePokemon => _settings.RenamePokemon;

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -9,6 +9,8 @@ using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
 using POGOProtos.Inventory.Item;
 using PoGo.NecroBot.Logic.Common;
+using System.Collections.Generic;
+using POGOProtos.Data;
 
 #endregion
 
@@ -32,15 +34,21 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (pokemonToEvolve.Any())
             {
-                if (session.LogicSettings.KeepPokemonsThatCanEvolve)
+                if (session.LogicSettings.AlwaysEvolveWithLuckyEggWhenMinPokemonAmountOccurs && await shouldUseLuckyEgg(session, pokemonToEvolve))
+                {
+                    await UseLuckyEgg(session);
+                    await evolve(session, pokemonToEvolve);
+                    return;
+                }
+                else if (session.LogicSettings.KeepPokemonsThatCanEvolve)
                 {
                     var totalPokemon = await session.Inventory.GetPokemons();
 
-                    var pokemonNeededInInventory = session.Profile.PlayerData.MaxPokemonStorage * session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage/100.0f;
+                    var pokemonNeededInInventory = session.Profile.PlayerData.MaxPokemonStorage * session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage / 100.0f;
                     var needPokemonToStartEvolve = Math.Round(
-                        Math.Max(0, 
+                        Math.Max(0,
                             Math.Min(pokemonNeededInInventory, session.Profile.PlayerData.MaxPokemonStorage)));
-                    
+
                     var deltaCount = needPokemonToStartEvolve - totalPokemon.Count();
 
                     if (deltaCount > 0)
@@ -50,64 +58,15 @@ namespace PoGo.NecroBot.Logic.Tasks
                             Message = session.Translation.GetTranslation(TranslationString.WaitingForMorePokemonToEvolve,
                                 pokemonToEvolve.Count, deltaCount, totalPokemon.Count(), needPokemonToStartEvolve, session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage)
                         });
-
                         return;
                     }
-                }
+                } 
 
-                var inventoryContent = await session.Inventory.GetItems();
-
-                var luckyEggs = inventoryContent.Where(p => p.ItemId == ItemId.ItemLuckyEgg);
-                var luckyEgg = luckyEggs.FirstOrDefault();
-
-                if (session.LogicSettings.UseLuckyEggsWhileEvolving && luckyEgg != null && luckyEgg.Count > 0)
+                if (await shouldUseLuckyEgg(session, pokemonToEvolve))
                 {
-                    if (pokemonToEvolve.Count >= session.LogicSettings.UseLuckyEggsMinPokemonAmount)
-                    {
-                        await UseLuckyEgg(session);
-                    }
-                    else
-                    {
-                        var evolvablePokemon = await session.Inventory.GetPokemons();
-
-                        var deltaPokemonToUseLuckyEgg = session.LogicSettings.UseLuckyEggsMinPokemonAmount -
-                                                                   pokemonToEvolve.Count;
-
-                        var availableSpace = session.Profile.PlayerData.MaxPokemonStorage - evolvablePokemon.Count();
-
-                        if (deltaPokemonToUseLuckyEgg > availableSpace)
-                        {
-                            var possibleLimitInThisIteration = pokemonToEvolve.Count + availableSpace;
-
-                            session.EventDispatcher.Send(new NoticeEvent()
-                            {
-                                Message = session.Translation.GetTranslation(TranslationString.UseLuckyEggsMinPokemonAmountTooHigh,
-                                    session.LogicSettings.UseLuckyEggsMinPokemonAmount, possibleLimitInThisIteration)
-                            });
-                        }
-                        else
-                        {
-                            session.EventDispatcher.Send(new NoticeEvent()
-                            {
-                                Message = session.Translation.GetTranslation(TranslationString.CatchMorePokemonToUseLuckyEgg,
-                                    deltaPokemonToUseLuckyEgg)
-                            });
-                        }
-                    }
+                    await UseLuckyEgg(session);
                 }
-
-                foreach (var pokemon in pokemonToEvolve)
-                {
-                    // no cancellationToken.ThrowIfCancellationRequested here, otherwise the lucky egg would be wasted.
-                    var evolveResponse = await session.Client.Inventory.EvolvePokemon(pokemon.Id);
-
-                    session.EventDispatcher.Send(new PokemonEvolveEvent
-                    {
-                        Id = pokemon.PokemonId,
-                        Exp = evolveResponse.ExperienceAwarded,
-                        Result = evolveResponse.Result
-                    });
-                }
+                await evolve(session, pokemonToEvolve);
             }
         }
 
@@ -126,6 +85,67 @@ namespace PoGo.NecroBot.Logic.Tasks
             await session.Inventory.RefreshCachedInventory();
             if (luckyEgg != null) session.EventDispatcher.Send(new UseLuckyEggEvent {Count = luckyEgg.Count});
             DelayingUtils.Delay(session.LogicSettings.DelayBetweenPokemonCatch, 2000);
+        }
+
+        private static async Task evolve(ISession session, List<PokemonData> pokemonToEvolve)
+        {
+            foreach (var pokemon in pokemonToEvolve)
+            {
+                // no cancellationToken.ThrowIfCancellationRequested here, otherwise the lucky egg would be wasted.
+                var evolveResponse = await session.Client.Inventory.EvolvePokemon(pokemon.Id);
+
+                session.EventDispatcher.Send(new PokemonEvolveEvent
+                {
+                    Id = pokemon.PokemonId,
+                    Exp = evolveResponse.ExperienceAwarded,
+                    Result = evolveResponse.Result
+                });
+            }
+        }
+
+        private static async Task<Boolean> shouldUseLuckyEgg(ISession session, List<PokemonData> pokemonToEvolve)
+        {
+            var inventoryContent = await session.Inventory.GetItems();
+
+            var luckyEggs = inventoryContent.Where(p => p.ItemId == ItemId.ItemLuckyEgg);
+            var luckyEgg = luckyEggs.FirstOrDefault();
+
+            if (session.LogicSettings.UseLuckyEggsWhileEvolving && luckyEgg != null && luckyEgg.Count > 0)
+            {
+                if (pokemonToEvolve.Count >= session.LogicSettings.UseLuckyEggsMinPokemonAmount)
+                {
+                    return true;
+                }
+                else
+                {
+                    var evolvablePokemon = await session.Inventory.GetPokemons();
+
+                    var deltaPokemonToUseLuckyEgg = session.LogicSettings.UseLuckyEggsMinPokemonAmount -
+                                                               pokemonToEvolve.Count;
+
+                    var availableSpace = session.Profile.PlayerData.MaxPokemonStorage - evolvablePokemon.Count();
+
+                    if (deltaPokemonToUseLuckyEgg > availableSpace)
+                    {
+                        var possibleLimitInThisIteration = pokemonToEvolve.Count + availableSpace;
+
+                        session.EventDispatcher.Send(new NoticeEvent()
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.UseLuckyEggsMinPokemonAmountTooHigh,
+                                session.LogicSettings.UseLuckyEggsMinPokemonAmount, possibleLimitInThisIteration)
+                        });
+                    }
+                    else
+                    {
+                        session.EventDispatcher.Send(new NoticeEvent()
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.CatchMorePokemonToUseLuckyEgg,
+                                deltaPokemonToUseLuckyEgg)
+                        });
+                    }
+                }
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
I wanted a way to use the nice logic for KeepPokemonsThatCanEvolve = true and use a lucky egg when the UseLuckyEggsMinPokemonAmount criteria was met.

I therefore introduced a variable called 'AlwaysEvolveWithLuckyEggWhenMinPokemonAmountOccurs' which can be used together with KeepPokemonsThatCanEvolve = true.

We should maybe discuss what we want to do here if you dont like my idea. I think that KeepPokemonsThatCanEvolve  is good but i wanted to use it to _not_ transfer pokemonts and only use a lucky egg when UseLuckyEggsMinPokemonAmount  was met.

Any input?