### PR TITLE
Put LastPos.ini into profile directories

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -19,6 +19,7 @@ namespace PoGo.NecroBot.CLI
     internal class Program
     {
         private static readonly ManualResetEvent QuitEvent = new ManualResetEvent(false);
+        private static var subPath = "";
         private static void Main(string[] args)
         {
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionEventHandler;
@@ -32,7 +33,6 @@ namespace PoGo.NecroBot.CLI
 
             CultureInfo.DefaultThreadCurrentCulture = culture;
             Thread.CurrentThread.CurrentCulture = culture;
-            var subPath = "";
             if (args.Length > 0)
                 subPath = args[0];
 
@@ -105,8 +105,7 @@ namespace PoGo.NecroBot.CLI
 
         private static void SaveLocationToDisk(double lat, double lng)
         {
-            var coordsPath = Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + "Config" +
-                             Path.DirectorySeparatorChar + "LastPos.ini";
+            var coordsPath = Path.Combine(Directory.GetCurrentDirectory(), subPath, "Config", "LastPos.ini");
 
             File.WriteAllText(coordsPath, $"{lat}:{lng}");
         }

--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -19,7 +19,7 @@ namespace PoGo.NecroBot.CLI
     internal class Program
     {
         private static readonly ManualResetEvent QuitEvent = new ManualResetEvent(false);
-        private static var subPath = "";
+        private static string subPath = "";
         private static void Main(string[] args)
         {
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionEventHandler;

--- a/PoGo.NecroBot.Logic/State/PositionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/PositionCheckState.cs
@@ -18,8 +18,7 @@ namespace PoGo.NecroBot.Logic.State
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var coordsPath = Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + "Config" +
-                             Path.DirectorySeparatorChar + "LastPos.ini";
+            var coordsPath = Path.Combine(session.LogicSettings.ProfileConfigPath, "LastPos.ini");
             if (File.Exists(coordsPath))
             {
                 var latLngFromFile = LoadPositionFromDisk(session);
@@ -79,14 +78,11 @@ namespace PoGo.NecroBot.Logic.State
         private static Tuple<double, double> LoadPositionFromDisk(ISession session)
         {
             if (
-                File.Exists(Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + "Config" +
-                            Path.DirectorySeparatorChar + "LastPos.ini") &&
-                File.ReadAllText(Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + "Config" +
-                                 Path.DirectorySeparatorChar + "LastPos.ini").Contains(":"))
+                File.Exists(Path.Combine(session.LogicSettings.ProfileConfigPath, "LastPos.ini")) &&
+                File.ReadAllText(Path.Combine(session.LogicSettings.ProfileConfigPath, "LastPos.ini")).Contains(":"))
             {
                 var latlngFromFile =
-                    File.ReadAllText(Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + "Config" +
-                                     Path.DirectorySeparatorChar + "LastPos.ini");
+                    File.ReadAllText(Path.Combine(session.LogicSettings.ProfileConfigPath, "LastPos.ini"));
                 var latlng = latlngFromFile.Split(':');
                 if (latlng[0].Length != 0 && latlng[1].Length != 0)
                 {


### PR DESCRIPTION
LastPos.ini was saved in the same location regardless of profile causing bots to constantly overwrite the other bots last position in the file. Also caused crashes when multiple bots tried to access the file at the same time.