### PR TITLE
Improve/fix default values

### DIFF
--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -171,7 +171,7 @@ namespace PoGo.NecroBot.Logic
         public int KeepMinCp;
         [DefaultValue(90)]
         public float KeepMinIvPercentage;
-        [DefaultValue("and")]
+        [DefaultValue("or")]
         public string KeepMinOperator;
         [DefaultValue(false)]
         public bool PrioritizeIvOverCp;


### PR DESCRIPTION
Setting it to "or" should be default because that's the way this tool behaved before 9d86123777a208562a642ae18968a53bf0f0d7a6 messed it up.