### PR TITLE
prevent wrong Evolve behavior, pls do n't change meaning of mnemonic parameters

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -34,23 +34,26 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (pokemonToEvolve.Any())
             {
-                var totalPokemon = await session.Inventory.GetPokemons();
-
-                var pokemonNeededInInventory = session.Profile.PlayerData.MaxPokemonStorage * session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage / 100.0f;
-                var needPokemonToStartEvolve = Math.Round(
-                    Math.Max(0,
-                        Math.Min(pokemonNeededInInventory, session.Profile.PlayerData.MaxPokemonStorage)));
-
-                var deltaCount = needPokemonToStartEvolve - totalPokemon.Count();
-
-                if (deltaCount > 0)
+                if (session.LogicSettings.KeepPokemonsThatCanEvolve)
                 {
-                    session.EventDispatcher.Send(new NoticeEvent()
+                    var totalPokemon = await session.Inventory.GetPokemons();
+
+                    var pokemonNeededInInventory = session.Profile.PlayerData.MaxPokemonStorage * session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage / 100.0f;
+                    var needPokemonToStartEvolve = Math.Round(
+                        Math.Max(0,
+                            Math.Min(pokemonNeededInInventory, session.Profile.PlayerData.MaxPokemonStorage)));
+
+                    var deltaCount = needPokemonToStartEvolve - totalPokemon.Count();
+
+                    if (deltaCount > 0)
                     {
-                        Message = session.Translation.GetTranslation(TranslationString.WaitingForMorePokemonToEvolve,
-                            pokemonToEvolve.Count, deltaCount, totalPokemon.Count(), needPokemonToStartEvolve, session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage)
-                    });
-                    return;
+                        session.EventDispatcher.Send(new NoticeEvent()
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.WaitingForMorePokemonToEvolve,
+                                pokemonToEvolve.Count, deltaCount, totalPokemon.Count(), needPokemonToStartEvolve, session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage)
+                        });
+                        return;
+                    }
                 }
 
                 if (await shouldUseLuckyEgg(session, pokemonToEvolve))


### PR DESCRIPTION
pls, dont break the logic of evolve behavior, analyze and test your changes before commit to master, Evolve*KEPT*PokemonsAtStorageUsagePercentage have only one certain meaning. If you want change logic then pls rename parameter to EvolvePokemonsAtStorageUsagePercentage without KEPT.

Without this check people who wants to evolve pokemon with above IV or just with enough candy, but with options KeepPokemonsThatCanEvolve = false (case with default config for new users) will never have it, and even their pokemon might be transfered instead of evolving... (sry for my bad english)