### PR TITLE
added support for random walking speed

### DIFF
--- a/PoGo.NecroBot.CLI/Config/Translations/translation.de.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.de.json
@@ -39,7 +39,7 @@
     },
     {
       "Key": "eventFortTargeted",
-      "Value": "{0} in ({1}m)"
+      "Value": "{0} in ({1}m)(~{2} Sekunden)"
     },
     {
       "Key": "eventProfileLogin",

--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -114,7 +114,8 @@ namespace PoGo.NecroBot.CLI
 
         private static void HandleEvent(FortTargetEvent fortTargetEvent, ISession session)
         {
-            int intTimeForArrival = (int) ( fortTargetEvent.Distance / ( session.LogicSettings.WalkingSpeedInKilometerPerHour * 0.277778 ) );
+            double meanWalkingSpeed = (session.LogicSettings.MinWalkingSpeedInKilometerPerHour + session.LogicSettings.MaxWalkingSpeedInKilometerPerHour) / 2.0;
+            int intTimeForArrival = (int) ( fortTargetEvent.Distance / (meanWalkingSpeed * 0.277778 ) );
 
             Logger.Write(
                 session.Translation.GetTranslation(TranslationString.EventFortTargeted, fortTargetEvent.Name,

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -181,7 +181,7 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(TranslationString.EventFortFailed,
                 "Name: {0} INFO: Looting failed, possible softban. Unban in: {1}/{2}"),
             new KeyValuePair<TranslationString, string>(TranslationString.EventFortTargeted,
-                "Traveling to Pokestop: {0} ({1}m)({2}seconds)"),
+                "Traveling to Pokestop: {0} ({1}m)(~{2} seconds)"),
             new KeyValuePair<TranslationString, string>(TranslationString.EventProfileLogin, "Playing as {0}"),
             new KeyValuePair<TranslationString, string>(TranslationString.EventUsedIncense,
                 "Used Incense, remaining: {0}"),

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -72,7 +72,8 @@ namespace PoGo.NecroBot.Logic
         float KeepMinIvPercentage { get; }
         int KeepMinCp { get; }
         string KeepMinOperator { get; }
-        double WalkingSpeedInKilometerPerHour { get; }
+        double MinWalkingSpeedInKilometerPerHour { get; }
+        double MaxWalkingSpeedInKilometerPerHour { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }
         bool KeepPokemonsThatCanEvolve { get; }
         bool TransferDuplicatePokemon { get; }

--- a/PoGo.NecroBot.Logic/Navigation.cs
+++ b/PoGo.NecroBot.Logic/Navigation.cs
@@ -35,14 +35,14 @@ namespace PoGo.NecroBot.Logic
         }
 
         public async Task<PlayerUpdateResponse> Move(GeoCoordinate targetLocation,
-            double walkingSpeedInKilometersPerHour, Func<Task<bool>> functionExecutedWhileWalking,
+            double minWalkingSpeedInKilometersPerHour, double maxWalkingSpeedInKilometersPerHour, Func<Task<bool>> functionExecutedWhileWalking,
             CancellationToken cancellationToken, bool disableHumanLikeWalking)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             if (!disableHumanLikeWalking)
             {
-                var speedInMetersPerSecond = walkingSpeedInKilometersPerHour / 3.6;
+                var speedInMetersPerSecond = LocationUtils.getRandomWalkingSpeed(minWalkingSpeedInKilometersPerHour, maxWalkingSpeedInKilometersPerHour) / 3.6;
 
                 var sourceLocation = new GeoCoordinate(_client.CurrentLatitude, _client.CurrentLongitude);
                 LocationUtils.CalculateDistanceInMeters(sourceLocation, targetLocation);
@@ -80,6 +80,7 @@ namespace PoGo.NecroBot.Logic
                         }
                     }
 
+                    speedInMetersPerSecond = LocationUtils.getRandomWalkingSpeed(minWalkingSpeedInKilometersPerHour, maxWalkingSpeedInKilometersPerHour) / 3.6;
                     nextWaypointDistance = Math.Min(currentDistanceToTarget,
                         millisecondsUntilGetUpdatePlayerLocationResponse / 1000 * speedInMetersPerSecond);
                     nextWaypointBearing = LocationUtils.DegreeBearing(sourceLocation, targetLocation);
@@ -114,7 +115,7 @@ namespace PoGo.NecroBot.Logic
         }
 
         public async Task<PlayerUpdateResponse> HumanPathWalking(GpxReader.Trkpt trk,
-            double walkingSpeedInKilometersPerHour, Func<Task<bool>> functionExecutedWhileWalking,
+            double minWalkingSpeedInKilometersPerHour, double maxWalkingSpeedInKilometersPerHour, Func<Task<bool>> functionExecutedWhileWalking,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -124,7 +125,7 @@ namespace PoGo.NecroBot.Logic
             var targetLocation = new GeoCoordinate(Convert.ToDouble(trk.Lat, CultureInfo.InvariantCulture),
                 Convert.ToDouble(trk.Lon, CultureInfo.InvariantCulture));
 
-            var speedInMetersPerSecond = walkingSpeedInKilometersPerHour/3.6;
+            var speedInMetersPerSecond = LocationUtils.getRandomWalkingSpeed(minWalkingSpeedInKilometersPerHour, minWalkingSpeedInKilometersPerHour )/ 3.6;
 
             var sourceLocation = new GeoCoordinate(_client.CurrentLatitude, _client.CurrentLongitude);
             LocationUtils.CalculateDistanceInMeters(sourceLocation, targetLocation);
@@ -163,6 +164,7 @@ namespace PoGo.NecroBot.Logic
                 //    }
                 //}
 
+                speedInMetersPerSecond = LocationUtils.getRandomWalkingSpeed(minWalkingSpeedInKilometersPerHour, minWalkingSpeedInKilometersPerHour) / 3.6;
                 nextWaypointDistance = Math.Min(currentDistanceToTarget,
                     millisecondsUntilGetUpdatePlayerLocationResponse/1000*speedInMetersPerSecond);
                 nextWaypointBearing = LocationUtils.DegreeBearing(sourceLocation, targetLocation);

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -144,7 +144,9 @@ namespace PoGo.NecroBot.Logic
         [DefaultValue(-73.962277)]
         public double DefaultLongitude;
         [DefaultValue(31.0)]
-        public double WalkingSpeedInKilometerPerHour;
+        public double MinWalkingSpeedInKilometerPerHour;
+        [DefaultValue(31.0)]
+        public double MaxWalkingSpeedInKilometerPerHour;
         [DefaultValue(10)]
         public int MaxSpawnLocationOffset;
         //delays
@@ -730,7 +732,8 @@ namespace PoGo.NecroBot.Logic
         public float UpgradePokemonIvMinimum => _settings.UpgradePokemonIvMinimum;
         public float UpgradePokemonCpMinimum => _settings.UpgradePokemonCpMinimum;
         public string UpgradePokemonMinimumStatsOperator => _settings.UpgradePokemonMinimumStatsOperator;
-        public double WalkingSpeedInKilometerPerHour => _settings.WalkingSpeedInKilometerPerHour;
+        public double MinWalkingSpeedInKilometerPerHour => _settings.MinWalkingSpeedInKilometerPerHour;
+        public double MaxWalkingSpeedInKilometerPerHour => _settings.MaxWalkingSpeedInKilometerPerHour;
         public bool EvolveAllPokemonWithEnoughCandy => _settings.EvolveAllPokemonWithEnoughCandy;
         public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve; 
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -164,7 +164,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                         await session.Navigation.HumanPathWalking(
                             trackPoints.ElementAt(curTrkPt),
-                            session.LogicSettings.WalkingSpeedInKilometerPerHour,
+                            LocationUtils.getRandomWalkingSpeed(session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour),
                             async () =>
                             {
                                 await CatchNearbyPokemonsTask.Execute(session, cancellationToken);

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -164,7 +164,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                         await session.Navigation.HumanPathWalking(
                             trackPoints.ElementAt(curTrkPt),
-                            LocationUtils.getRandomWalkingSpeed(session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour),
+                            session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour,
                             async () =>
                             {
                                 await CatchNearbyPokemonsTask.Execute(session, cancellationToken);

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -41,7 +41,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 await session.Navigation.Move(
                     new GeoCoordinate(session.Settings.DefaultLatitude, session.Settings.DefaultLongitude),
-                        LocationUtils.getRandomWalkingSpeed(session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour),
+                        session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour,
                         null, cancellationToken, session.LogicSettings.DisableHumanWalking);
             }
 
@@ -81,7 +81,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 session.EventDispatcher.Send(new FortTargetEvent { Name = fortInfo.Name, Distance = distance });
 
                 await session.Navigation.Move(new GeoCoordinate(pokeStop.Latitude, pokeStop.Longitude),
-                LocationUtils.getRandomWalkingSpeed(session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour),
+                session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour,
                 async () =>
                 {
                     // Catch normal map Pokemon

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -38,10 +38,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                 Logger.Write(
                     session.Translation.GetTranslation(TranslationString.FarmPokestopsOutsideRadius, distanceFromStart),
                     LogLevel.Warning);
-                
+
                 await session.Navigation.Move(
                     new GeoCoordinate(session.Settings.DefaultLatitude, session.Settings.DefaultLongitude),
-                    session.LogicSettings.WalkingSpeedInKilometerPerHour, null, cancellationToken, session.LogicSettings.DisableHumanWalking);
+                        LocationUtils.getRandomWalkingSpeed(session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour),
+                        null, cancellationToken, session.LogicSettings.DisableHumanWalking);
             }
 
             var pokestopList = await GetPokeStops(session);
@@ -58,7 +59,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 });
             }
 
-            session.EventDispatcher.Send(new PokeStopListEvent {Forts = pokestopList});
+            session.EventDispatcher.Send(new PokeStopListEvent { Forts = pokestopList });
 
             while (pokestopList.Any())
             {
@@ -77,18 +78,18 @@ namespace PoGo.NecroBot.Logic.Tasks
                     session.Client.CurrentLongitude, pokeStop.Latitude, pokeStop.Longitude);
                 var fortInfo = await session.Client.Fort.GetFort(pokeStop.Id, pokeStop.Latitude, pokeStop.Longitude);
 
-                session.EventDispatcher.Send(new FortTargetEvent {Name = fortInfo.Name, Distance = distance});
+                session.EventDispatcher.Send(new FortTargetEvent { Name = fortInfo.Name, Distance = distance });
 
-                    await session.Navigation.Move(new GeoCoordinate(pokeStop.Latitude, pokeStop.Longitude),
-                    session.LogicSettings.WalkingSpeedInKilometerPerHour,
-                    async () =>
-                    {
-                        // Catch normal map Pokemon
-                        await CatchNearbyPokemonsTask.Execute(session, cancellationToken);
-                        //Catch Incense Pokemon
-                        await CatchIncensePokemonsTask.Execute(session, cancellationToken);
-                        return true;
-                    }, cancellationToken, session.LogicSettings.DisableHumanWalking);
+                await session.Navigation.Move(new GeoCoordinate(pokeStop.Latitude, pokeStop.Longitude),
+                LocationUtils.getRandomWalkingSpeed(session.LogicSettings.MinWalkingSpeedInKilometerPerHour, session.LogicSettings.MaxWalkingSpeedInKilometerPerHour),
+                async () =>
+                {
+                    // Catch normal map Pokemon
+                    await CatchNearbyPokemonsTask.Execute(session, cancellationToken);
+                    //Catch Incense Pokemon
+                    await CatchIncensePokemonsTask.Execute(session, cancellationToken);
+                    return true;
+                }, cancellationToken, session.LogicSettings.DisableHumanWalking);
 
                 //Catch Lure Pokemon
                 if (pokeStop.LureInfo != null)
@@ -116,10 +117,10 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                         if (timesZeroXPawarded > zeroCheck)
                         {
-                            if ((int) fortSearch.CooldownCompleteTimestampMs != 0)
+                            if ((int)fortSearch.CooldownCompleteTimestampMs != 0)
                             {
                                 break;
-                                    // Check if successfully looted, if so program can continue as this was "false alarm".
+                                // Check if successfully looted, if so program can continue as this was "false alarm".
                             }
 
                             fortTry += 1;
@@ -225,7 +226,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                             LocationUtils.CalculateDistanceInMeters(
                                 session.Settings.DefaultLatitude, session.Settings.DefaultLongitude,
                                 i.Latitude, i.Longitude) < session.LogicSettings.MaxTravelDistanceInMeters ||
-                        session.LogicSettings.MaxTravelDistanceInMeters == 0) 
+                        session.LogicSettings.MaxTravelDistanceInMeters == 0)
                 );
 
             return pokeStops.ToList();

--- a/PoGo.NecroBot.Logic/Utils/LocationUtils.cs
+++ b/PoGo.NecroBot.Logic/Utils/LocationUtils.cs
@@ -9,6 +9,8 @@ namespace PoGo.NecroBot.Logic.Utils
 {
     public static class LocationUtils
     {
+        private static Random r = new Random();
+
         public static double CalculateDistanceInMeters(double sourceLat, double sourceLng, double destLat,
             double destLng)
             // from http://stackoverflow.com/questions/6366408/calculating-distance-between-two-latitude-and-longitude-geocoordinates
@@ -107,6 +109,13 @@ namespace PoGo.NecroBot.Logic.Utils
         public static double ToRad(double degrees)
         {
             return degrees*(Math.PI/180);
+        }
+
+        public static double getRandomWalkingSpeed(double min, double max)
+        {
+            if (min > max)
+                return min;
+            return min + (max - min) * r.NextDouble();
         }
     }
 }


### PR DESCRIPTION
PR is related to this issue: [https://github.com/NECROBOTIO/NecroBot/issues/2140](https://github.com/NECROBOTIO/NecroBot/issues/2140)

two new settings:
"MinWalkingSpeedInKilometerPerHour": 31.0,
"MaxWalkingSpeedInKilometerPerHour": 31.0,

per default both settings are set to the same value so its just as the old behaviour -> constant speed
but one can vary the values now to achieve a random walking speed.

One thing that would be nice is missing yet:
Transfer the old "WalkingSpeedInKilometerPerHour" of the users to the new settings. It just sets the defaults of 31 now, which is also the default WalkingSpeedInKilometerPerHour if nothing is set before.

If you can answer me how to do it, i can make another commit.