### PR TITLE
changed egg prio for unlimited incubator

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
@@ -73,7 +73,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                 if (incubator.PokemonId == 0)
                 {
                     // Unlimited incubators prefer short eggs, limited incubators prefer long eggs
-                    var egg = incubator.ItemId == ItemId.ItemIncubatorBasicUnlimited
+                    // Special case: If only one incubator is available at all, it will prefer long eggs
+                    var egg = (incubator.ItemId == ItemId.ItemIncubatorBasicUnlimited && incubators.Count > 1)
                         ? unusedEggs.FirstOrDefault()
                         : unusedEggs.LastOrDefault();
 


### PR DESCRIPTION
Issue: [https://github.com/NECROBOTIO/NecroBot/issues/1579](https://github.com/NECROBOTIO/NecroBot/issues/1579)

Implemented as suggested in the issue:
The unlimited incubator will prefer long eggs if no limited incubators are available anymore.