### PR TITLE
add non-tls socket for webui

### DIFF
--- a/PoGo.NecroBot.CLI/WebSocketInterface.cs
+++ b/PoGo.NecroBot.CLI/WebSocketInterface.cs
@@ -12,6 +12,7 @@ using SuperSocket.SocketBase;
 using SuperSocket.SocketBase.Config;
 using SuperSocket.WebSocket;
 using System;
+using System.Collections.Generic;
 
 #endregion
 
@@ -31,19 +32,29 @@ namespace PoGo.NecroBot.CLI
             var translations = session.Translation;
             _server = new WebSocketServer();
             _websocketHandler = WebSocketEventManager.CreateInstance();
-            var setupComplete = _server.Setup(new ServerConfig
+            var config = new ServerConfig
             {
                 Name = "NecroWebSocket",
-                Ip = "Any",
-                Port = port,
                 Mode = SocketMode.Tcp,
-                Security = "tls",
                 Certificate = new CertificateConfig
                 {
                     FilePath = @"cert.pfx",
                     Password = "necro"
+                },
+            };
+            config.Listeners = new List<ListenerConfig>
+            {
+                new ListenerConfig()
+                {
+                    Ip = "Any", Port = port, Security = "tls"
+                },
+                new ListenerConfig()
+                {
+                    Ip = "Any", Port = port + 1, Security = "none"
                 }
-            });
+            };
+
+            var setupComplete = _server.Setup(config);
 
             if (setupComplete == false)
             {


### PR DESCRIPTION
I'm working on a web ui accessible for everyone through the browser.
however, to do that, we need either non-tls or a signed certificate.

I've added a new non-tls endpoint without deleting the old one for compatibility reason