### PR TITLE
Use only pokezz, not both.

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -229,6 +229,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                                     await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
                                     LocsVisited.Add(new PokemonLocation(location.Latitude, location.Longitude));
                                 }
+                                return;
                             }
                         }
 


### PR DESCRIPTION
Only uses pokezz to snipe instead of using both.