### PR TITLE
German translation correction

### DIFF
--- a/PoGo.NecroBot.CLI/Config/Translations/translation.de.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.de.json
@@ -571,7 +571,7 @@
     },
     {
       "Key": "nidoranFemale",
-      "Value": "NidoranF"
+      "Value": "NidoranW"
     },
     {
       "Key": "nidorina",
@@ -595,7 +595,7 @@
     },
     {
       "Key": "clefairy",
-      "Value": "Pipi"
+      "Value": "Piepi"
     },
     {
       "Key": "clefable",
@@ -755,7 +755,7 @@
     },
     {
       "Key": "graveler",
-      "Value": "Georock"
+      "Value": "Georok"
     },
     {
       "Key": "golem",
@@ -855,11 +855,11 @@
     },
     {
       "Key": "voltorb",
-      "Value": "Voltoball"
+      "Value": "Voltobal"
     },
     {
       "Key": "electrode",
-      "Value": "Lektroball"
+      "Value": "Lektrobal"
     },
     {
       "Key": "exeggcute",
@@ -1055,7 +1055,7 @@
     },
     {
       "Key": "mewtwo",
-      "Value": "Mewto"
+      "Value": "Mewtu"
     },
     {
       "Key": "mew",


### PR DESCRIPTION
Some (5) Pokémon names were misspelled in the German translation file.

explanation for the change from "NidoranF" to "NidoranW"
In German it's
Female = Weiblich = W -> NidoranW
Male = Männlich = M -> NidoranM