### PR TITLE
Added multiple usability improvements

### DIFF
--- a/KillSwitch.txt
+++ b/KillSwitch.txt
@@ -1,0 +1,2 @@
+BotStatus=ENABLED;
+Change the above to | DISABLED | and enter a description here

--- a/KillSwitch.txt
+++ b/KillSwitch.txt
@@ -1,2 +1,2 @@
-BotStatus=DISABLED;
-THE BOT HAS BEEN DISABLED FOR SOME REASON
+BotStatus=ENABLED;
+Switch the above to DISABLED to turn off the bot and write anything on the following lines to print details of the reason

--- a/PoGo.NecroBot.CLI/Config/Translations/translation.fr.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.fr.json
@@ -489,8 +489,104 @@
       "Value": "{0} utilisé, reste {1}"
     },
     {
-      "Key": "itemRazzBerry", 
+      "Key": "itemRazzBerry",
       "Value": "Baie Framby"
+    },
+    {
+      "Key": "firstStartPrompt",
+      "Value": "[FR]This is your first start, would you like to begin setup? {0}/{1}"
+    },
+    {
+      "Key": "firstStartLanguagePrompt",
+      "Value": "[FR]Would you like to change the default language? {0}/{1}"
+    },
+    {
+      "Key": "firstStartLanguageCodePrompt",
+      "Value": "[FR]Please enter a new language code"
+    },
+    {
+      "Key": "firstStartLanguageConfirm",
+      "Value": "[FR]Language Code Applied: {0}"
+    },
+    {
+      "Key": "promptError",
+      "Value": "[FR][INPUT ERROR] Error with input, please enter '{0}' or '{1}"
+    },
+    {
+      "Key": "firstStartAutoGenSettings",
+      "Value": "[FR]Config/Auth file automatically generated and must be completed before continuing"
+    },
+    {
+      "Key": "firstStartSetupAccount",
+      "Value": "[FR]### Setting up new USER ACCOUNT ###"
+    },
+    {
+      "Key": "firstStartSetupTypePrompt",
+      "Value": "[FR]Please choose an account type: {0}/{1}"
+    },
+    {
+      "Key": "firstStartSetupTypeConfirm",
+      "Value": "[FR]Chosen Account Type: {0}"
+    },
+    {
+      "Key": "firstStartSetupTypePromptError",
+      "Value": "[FR][ERROR] submitted an incorrect account type, please choose '{0}' or '{1}'"
+    },
+    {
+      "Key": "firstStartSetupUsernamePrompt",
+      "Value": "[FR]Please enter a Username"
+    },
+    {
+      "Key": "firstStartSetupUsernameConfirm",
+      "Value": "[FR]Accepted username: {0}"
+    },
+    {
+      "Key": "firstStartSetupPasswordPrompt",
+      "Value": "[FR]Please enter a Password"
+    },
+    {
+      "Key": "firstStartSetupPasswordConfirm",
+      "Value": "[FR]Accepted password: {0}"
+    },
+    {
+      "Key": "firstStartAccountCompleted",
+      "Value": "[FR]### User Account Completed ###"
+    },
+    {
+      "Key": "firstStartDefaultLocationPrompt",
+      "Value": "[FR]Would you like to setup a new Default Location? {0}/{1}"
+    },
+    {
+      "Key": "firstStartDefaultLocationSet",
+      "Value": "[FR]Default Location Applied"
+    },
+    {
+      "Key": "firstStartDefaultLocation",
+      "Value": "[FR]### Setting Default Position ###"
+    },
+    {
+      "Key": "firstStartSetupDefaultLocationError",
+      "Value": "[FR][ERROR] Please input only a VALUE for example: {0}"
+    },
+    {
+      "Key": "firstStartSetupDefaultLatPrompt",
+      "Value": "[FR]Please enter a Latitude (Right click to paste)"
+    },
+    {
+      "Key": "firstStartSetupDefaultLatConfirm",
+      "Value": "[FR]Lattitude accepted: {0}"
+    },
+    {
+      "Key": "firstStartSetupDefaultLongPrompt",
+      "Value": "[FR]Please enter a Longitude (Right click to paste)"
+    },
+    {
+      "Key": "firstStartSetupDefaultLongConfirm",
+      "Value": "[FR]Longitude accepted: {0}"
+    },
+    {
+      "Key": "firstStartSetupCompleted",
+      "Value": "[FR]### COMPLETED CONFIG SETUP ###"
     }
   ],
   "PokemonStrings": [

--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -256,10 +256,15 @@ namespace PoGo.NecroBot.CLI
             var candy = session.Translation.GetTranslation(TranslationString.DisplayHighestCandy);
 
             Logger.Write($"====== {strHeader} ======", LogLevel.Info, ConsoleColor.Yellow);
-            foreach (var pokemon in displayHighestsPokemonEvent.PokemonList)
+            foreach( var pokemon in displayHighestsPokemonEvent.PokemonList )
+            {
+                string strMove1 = session.Translation.GetPokemonMovesetTranslation( pokemon.Item5 );
+                string strMove2 = session.Translation.GetPokemonMovesetTranslation( pokemon.Item6 );
+
                 Logger.Write(
-                    $"# CP {pokemon.Item1.Cp.ToString().PadLeft(4, ' ')}/{pokemon.Item2.ToString().PadLeft(4, ' ')} | ({pokemon.Item3.ToString("0.00")}% {strPerfect})\t| Lvl {pokemon.Item4.ToString("00")}\t {strName}: {session.Translation.GetPokemonTranslation(pokemon.Item1.PokemonId).PadRight(10, ' ')}\t {move1}: {pokemon.Item5.ToString().PadRight(20, ' ')} {move2}: {pokemon.Item6.ToString().PadRight(20, ' ')} {candy}: {pokemon.Item7}",
-                    LogLevel.Info, ConsoleColor.Yellow);
+                    $"# CP {pokemon.Item1.Cp.ToString().PadLeft( 4, ' ' )}/{pokemon.Item2.ToString().PadLeft( 4, ' ' )} | ({pokemon.Item3.ToString( "0.00" )}% {strPerfect})\t| Lvl {pokemon.Item4.ToString( "00" )}\t {strName}: {session.Translation.GetPokemonTranslation( pokemon.Item1.PokemonId ).PadRight( 10, ' ' )}\t {move1}: {strMove1.PadRight( 20, ' ' )} {move2}: {strMove2.PadRight( 20, ' ' )} {candy}: {pokemon.Item7}",
+                    LogLevel.Info, ConsoleColor.Yellow );
+            }
         }
 
         private static void HandleEvent(EvolveCountEvent evolveCountEvent, ISession session )
@@ -267,9 +272,9 @@ namespace PoGo.NecroBot.CLI
             Logger.Write(session.Translation.GetTranslation(TranslationString.PkmPotentialEvolveCount, evolveCountEvent.Evolves), LogLevel.Update, ConsoleColor.White);
         }
 
-        private static void HandleEvent(UpdateEvent updateEvent, ISession session)
+        private static void HandleEvent( UpdateEvent updateEvent, ISession session )
         {
-            Logger.Write(updateEvent.ToString(), LogLevel.Update);
+            Logger.Write( updateEvent.ToString(), LogLevel.Update );
         }
 
         internal void Listen(IEvent evt, ISession session)

--- a/PoGo.NecroBot.CLI/ConsoleLogger.cs
+++ b/PoGo.NecroBot.CLI/ConsoleLogger.cs
@@ -107,6 +107,10 @@ namespace PoGo.NecroBot.CLI
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] ({LoggingStrings.Update}) {message}");
                     break;
+                case LogLevel.New:
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine( $"[{DateTime.Now.ToString( "HH:mm:ss" )}] ({LoggingStrings.New}) {message}" );
+                    break;
                 default:
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] ({LoggingStrings.Error}) {message}");

--- a/PoGo.NecroBot.CLI/Models/LoggingStrings.cs
+++ b/PoGo.NecroBot.CLI/Models/LoggingStrings.cs
@@ -33,6 +33,8 @@ namespace PoGo.NecroBot.CLI.Models
 
         internal static string Update;
 
+        internal static string New;
+
         internal static void SetStrings(ISession session)
         {
             Attention =
@@ -89,7 +91,11 @@ namespace PoGo.NecroBot.CLI.Models
 
             Update =
                 session?.Translation.GetTranslation(
-                    TranslationString.LogEntryUpdate) ?? "UPDATE";
+                    TranslationString.LogEntryUpdate ) ?? "UPDATE";
+
+            New =
+                session?.Translation.GetTranslation(
+                    TranslationString.LogEntryNew ) ?? "NEW";
         }
     }
 }

--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -11,6 +11,7 @@ using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Tasks;
 using PoGo.NecroBot.Logic.Utils;
 using System.IO;
+using System.Net;
 
 #endregion
 
@@ -20,6 +21,9 @@ namespace PoGo.NecroBot.CLI
     {
         private static readonly ManualResetEvent QuitEvent = new ManualResetEvent(false);
         private static string subPath = "";
+        private static string strKillSwitchUri =
+            "https://raw.githubusercontent.com/Andrerm124/NecroBot/master/KillSwitch.txt";
+
         private static void Main(string[] args)
         {
             string strCulture = Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName;
@@ -39,6 +43,9 @@ namespace PoGo.NecroBot.CLI
                 subPath = args[0];
 
             Logger.SetLogger(new ConsoleLogger(LogLevel.New), subPath);
+
+            if( CheckKillSwitch() )
+                return;
 
             var profilePath = Path.Combine( Directory.GetCurrentDirectory(), subPath );
             var profileConfigPath = Path.Combine( profilePath, "config" );
@@ -145,6 +152,34 @@ namespace PoGo.NecroBot.CLI
             var coordsPath = Path.Combine(Directory.GetCurrentDirectory(), subPath, "Config", "LastPos.ini");
 
             File.WriteAllText(coordsPath, $"{lat}:{lng}");
+        }
+
+        private static bool CheckKillSwitch( )
+        {
+            using( var wC = new WebClient() )
+            {
+                string strResponse = wC.DownloadString( strKillSwitchUri );
+                string[] strSplit = strResponse.Split( ';' );
+                
+                if( strSplit.Length > 1 )
+                {
+                    string strStatus = strSplit[ 0 ];
+                    string strReason = strSplit[ 1 ];
+
+                    if( strStatus.ToLower().Contains( "disable" ) )
+                    {
+                        Console.WriteLine( strReason + "\n" );
+
+                        Logger.Write( "The bot will now close, please press enter to continue", LogLevel.Error );
+                        Console.ReadLine();
+                        return true;
+                    }
+                }
+                else
+                    return false;
+            }
+
+            return false;
         }
 
         private static void UnhandledExceptionEventHandler(object obj, UnhandledExceptionEventArgs args)

--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -22,7 +22,7 @@ namespace PoGo.NecroBot.CLI
         private static readonly ManualResetEvent QuitEvent = new ManualResetEvent(false);
         private static string subPath = "";
         private static string strKillSwitchUri =
-            "https://raw.githubusercontent.com/Andrerm124/NecroBot/master/KillSwitch.txt";
+            "https://raw.githubusercontent.com/NECROBOTIO/NecroBot/master/KillSwitch.txt";
 
         private static void Main(string[] args)
         {
@@ -158,25 +158,30 @@ namespace PoGo.NecroBot.CLI
         {
             using( var wC = new WebClient() )
             {
-                string strResponse = wC.DownloadString( strKillSwitchUri );
-                string[] strSplit = strResponse.Split( ';' );
-                
-                if( strSplit.Length > 1 )
+                try
                 {
-                    string strStatus = strSplit[ 0 ];
-                    string strReason = strSplit[ 1 ];
+                    string strResponse = wC.DownloadString( strKillSwitchUri );
+                    string[] strSplit = strResponse.Split( ';' );
 
-                    if( strStatus.ToLower().Contains( "disable" ) )
+                    if( strSplit.Length > 1 )
                     {
-                        Console.WriteLine( strReason + "\n" );
+                        string strStatus = strSplit[ 0 ];
+                        string strReason = strSplit[ 1 ];
 
-                        Logger.Write( "The bot will now close, please press enter to continue", LogLevel.Error );
-                        Console.ReadLine();
-                        return true;
+                        if( strStatus.ToLower().Contains( "disable" ) )
+                        {
+                            Console.WriteLine( strReason + "\n" );
+
+                            Logger.Write( "The bot will now close, please press enter to continue", LogLevel.Error );
+                            Console.ReadLine();
+                            return true;
+                        }
                     }
+                    else
+                        return false;
+                } catch( WebException )
+                {
                 }
-                else
-                    return false;
             }
 
             return false;

--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -77,11 +77,11 @@ namespace PoGo.NecroBot.CLI
 
             var aggregator = new StatisticsAggregator(stats);
             var listener = new ConsoleEventListener();
-            var websocket = new WebSocketInterface(settings.WebSocketPort, session);
 
             session.EventDispatcher.EventReceived += evt => listener.Listen(evt, session);
             session.EventDispatcher.EventReceived += evt => aggregator.Listen(evt, session);
-            session.EventDispatcher.EventReceived += evt => websocket.Listen(evt, session);
+            if(settings.UseWebsocket)
+            session.EventDispatcher.EventReceived += evt => new WebSocketInterface(settings.WebSocketPort, session).Listen(evt, session);
 
             machine.SetFailureState(new LoginState());
 

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -799,12 +799,7 @@ namespace PoGo.NecroBot.Logic.Common
             return translation != default( string ) ? translation : $"Translation for move {move} is missing";
         }
 
-        public static Translation Load( ILogicSettings logicSettings )
-        {
-            return Load( logicSettings, new Translation() );
-        }
-
-        public static Translation Load(ILogicSettings logicSettings, Translation translations )
+        public static Translation Load(ILogicSettings logicSettings, Translation translations = new Translation() )
         {
             var translationsLanguageCode = logicSettings.TranslationLanguageCode;
             var translationPath = Path.Combine(logicSettings.GeneralConfigPath, "translations");

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -3,6 +3,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using PoGo.NecroBot.Logic.Logging;
+using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.Utils;
 using System;
 using System.Collections.Generic;
@@ -19,7 +20,9 @@ namespace PoGo.NecroBot.Logic.Common
 
         string GetTranslation(TranslationString translationString);
 
-        string GetPokemonTranslation(POGOProtos.Enums.PokemonId id);
+        string GetPokemonTranslation( POGOProtos.Enums.PokemonId id );
+
+        string GetPokemonMovesetTranslation( POGOProtos.Enums.PokemonMove move );
     }
 
     public enum TranslationString
@@ -77,6 +80,7 @@ namespace PoGo.NecroBot.Logic.Common
         LogEntryEgg,
         LogEntryDebug,
         LogEntryUpdate,
+        LogEntryNew,
         LoggingIn,
         PtcOffline,
         AccessTokenExpired,
@@ -154,6 +158,30 @@ namespace PoGo.NecroBot.Logic.Common
         PkmNotEnoughRessources,
         EventUsedIncense,
         SnipeServerOffline,
+        PromptError,
+        FirstStartLanguagePrompt,
+        FirstStartLanguageCodePrompt,
+        FirstStartLanguageConfirm,
+        FirstStartPrompt,
+        FirstStartAutoGenSettings,
+        FirstStartSetupAccount,
+        FirstStartSetupTypePrompt,
+        FirstStartSetupTypeConfirm,
+        FirstStartSetupTypePromptError,
+        FirstStartSetupUsernamePrompt,
+        FirstStartSetupUsernameConfirm,
+        FirstStartSetupPasswordPrompt,
+        FirstStartSetupPasswordConfirm,
+        FirstStartAccountCompleted,
+        FirstStartDefaultLocationPrompt,
+        FirstStartDefaultLocationSet,
+        FirstStartDefaultLocation,
+        FirstStartSetupDefaultLocationError,
+        FirstStartSetupDefaultLatPrompt,
+        FirstStartSetupDefaultLatConfirm,
+        FirstStartSetupDefaultLongPrompt,
+        FirstStartSetupDefaultLongConfirm,
+        FirstStartSetupCompleted,
     }
 
     public class Translation : ITranslation
@@ -244,6 +272,7 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(TranslationString.LogEntryEgg, "EGG"),
             new KeyValuePair<TranslationString, string>(TranslationString.LogEntryDebug, "DEBUG"),
             new KeyValuePair<TranslationString, string>(TranslationString.LogEntryUpdate, "UPDATE"),
+            new KeyValuePair<TranslationString, string>(TranslationString.LogEntryNew, "NEW"),
             new KeyValuePair<TranslationString, string>(TranslationString.LoggingIn, "Logging in using {0}"),
             new KeyValuePair<TranslationString, string>(TranslationString.PtcOffline,
                 "PTC Servers are probably down OR your credentials are wrong. Try google"),
@@ -367,7 +396,31 @@ namespace PoGo.NecroBot.Logic.Common
                 "[Evolves] Potential Evolves: {0}"),
             new KeyValuePair<TranslationString, string>(TranslationString.PkmNotEnoughRessources,
                 "Pokemon Upgrade Failed Not Enough Resources"),
-            new KeyValuePair<TranslationString, string>(TranslationString.SnipeServerOffline, "Sniping server is offline. Skipping...")
+            new KeyValuePair<TranslationString, string>(TranslationString.SnipeServerOffline, "Sniping server is offline. Skipping..."),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartPrompt, "This is your first start, would you like to begin setup? {0}/{1}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartLanguagePrompt, "Would you like to change the default language? {0}/{1}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartLanguageCodePrompt, "Please enter a new language code"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartLanguageConfirm, "Language Code Applied: {0}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.PromptError, "[INPUT ERROR] Error with input, please enter '{0}' or '{1}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartAutoGenSettings, "Config/Auth file automatically generated and must be completed before continuing"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupAccount, "### Setting up new USER ACCOUNT ###"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupTypePrompt, "Please choose an account type: {0}/{1}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupTypeConfirm, "Chosen Account Type: {0}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupTypePromptError, "[ERROR] submitted an incorrect account type, please choose '{0}' or '{1}'"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupUsernamePrompt, "Please enter a Username"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupUsernameConfirm, "Accepted username: {0}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupPasswordPrompt, "Please enter a Password"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupPasswordConfirm, "Accepted password: {0}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartAccountCompleted, "### User Account Completed ###"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartDefaultLocationPrompt, "Would you like to setup a new Default Location? {0}/{1}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartDefaultLocationSet, "Default Location Applied"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartDefaultLocation, "### Setting Default Position ###"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupDefaultLocationError, "[ERROR] Please input only a VALUE for example: {0}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupDefaultLatPrompt, "Please enter a Latitude (Right click to paste)"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupDefaultLatConfirm, "Lattitude accepted: {0}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupDefaultLongPrompt, "Please enter a Longitude (Right click to paste)"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupDefaultLongConfirm, "Longitude accepted: {0}"),
+            new KeyValuePair<TranslationString, string>(TranslationString.FirstStartSetupCompleted, "### COMPLETED CONFIG SETUP ###")
         };
 
         [JsonProperty("PokemonStrings",
@@ -530,6 +583,196 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<POGOProtos.Enums.PokemonId, string>((POGOProtos.Enums.PokemonId)151,"Mew"),
         };
 
+        [JsonProperty("PokemonMovesetStrings",
+        ItemTypeNameHandling = TypeNameHandling.Arrays,
+        ItemConverterType = typeof(KeyValuePairConverter),
+        ObjectCreationHandling = ObjectCreationHandling.Replace,
+        DefaultValueHandling = DefaultValueHandling.Populate)]
+        private readonly List<KeyValuePair<POGOProtos.Enums.PokemonMove, string>> _pokemonMovesetTranslationStrings =
+            new List<KeyValuePair< POGOProtos.Enums.PokemonMove, string>>()
+        {
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MoveUnset, "MoveUnset" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ThunderShock, "ThunderShock" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.QuickAttack, "QuickAttack" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Scratch, "Scratch" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Ember, "Ember" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.VineWhip, "VineWhip" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Tackle, "Tackle" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.RazorLeaf, "RazorLeaf" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.TakeDown, "TakeDown" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.WaterGun, "WaterGun" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Bite, "Bite" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Pound, "Pound" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DoubleSlap, "DoubleSlap" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Wrap, "Wrap" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.HyperBeam, "HyperBeam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Lick, "Lick" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DarkPulse, "DarkPulse" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Smog, "Smog" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Sludge, "Sludge" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MetalClaw, "MetalClaw" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ViceGrip, "ViceGrip" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FlameWheel, "FlameWheel" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Megahorn, "Megahorn" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.WingAttack, "WingAttack" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Flamethrower, "Flamethrower" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SuckerPunch, "SuckerPunch" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Dig, "Dig" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.LowKick, "LowKick" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.CrossChop, "CrossChop" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PsychoCut, "PsychoCut" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Psybeam, "Psybeam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Earthquake, "Earthquake" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.StoneEdge, "StoneEdge" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.IcePunch, "IcePunch" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.HeartStamp, "HeartStamp" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Discharge, "Discharge" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FlashCannon, "FlashCannon" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Peck, "Peck" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DrillPeck, "DrillPeck" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.IceBeam, "IceBeam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Blizzard, "Blizzard" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.AirSlash, "AirSlash" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.HeatWave, "HeatWave" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Twineedle, "Twineedle" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PoisonJab, "PoisonJab" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.AerialAce, "AerialAce" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DrillRun, "DrillRun" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PetalBlizzard, "PetalBlizzard" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MegaDrain, "MegaDrain" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BugBuzz, "BugBuzz" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PoisonFang, "PoisonFang" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.NightSlash, "NightSlash" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Slash, "Slash" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BubbleBeam, "BubbleBeam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Submission, "Submission" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.KarateChop, "KarateChop" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.LowSweep, "LowSweep" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.AquaJet, "AquaJet" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.AquaTail, "AquaTail" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SeedBomb, "SeedBomb" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Psyshock, "Psyshock" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.RockThrow, "RockThrow" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.AncientPower, "AncientPower" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.RockTomb, "RockTomb" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.RockSlide, "RockSlide" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PowerGem, "PowerGem" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ShadowSneak, "ShadowSneak" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ShadowPunch, "ShadowPunch" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ShadowClaw, "ShadowClaw" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.OminousWind, "OminousWind" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ShadowBall, "ShadowBall" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BulletPunch, "BulletPunch" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MagnetBomb, "MagnetBomb" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SteelWing, "SteelWing" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.IronHead, "IronHead" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ParabolicCharge, "ParabolicCharge" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Spark, "Spark" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ThunderPunch, "ThunderPunch" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Thunder, "Thunder" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Thunderbolt, "Thunderbolt" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Twister, "Twister" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DragonBreath, "DragonBreath" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DragonPulse, "DragonPulse" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DragonClaw, "DragonClaw" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DisarmingVoice, "DisarmingVoice" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DrainingKiss, "DrainingKiss" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DazzlingGleam, "DazzlingGleam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Moonblast, "Moonblast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PlayRough, "PlayRough" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.CrossPoison, "CrossPoison" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SludgeBomb, "SludgeBomb" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SludgeWave, "SludgeWave" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.GunkShot, "GunkShot" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MudShot, "MudShot" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BoneClub, "BoneClub" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Bulldoze, "Bulldoze" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MudBomb, "MudBomb" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FuryCutter, "FuryCutter" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BugBite, "BugBite" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SignalBeam, "SignalBeam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.XScissor, "XScissor" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FlameCharge, "FlameCharge" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FlameBurst, "FlameBurst" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FireBlast, "FireBlast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Brine, "Brine" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.WaterPulse, "WaterPulse" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Scald, "Scald" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.HydroPump, "HydroPump" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Psychic, "Psychic" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Psystrike, "Psystrike" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.IceShard, "IceShard" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.IcyWind, "IcyWind" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FrostBreath, "FrostBreath" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Absorb, "Absorb" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.GigaDrain, "GigaDrain" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FirePunch, "FirePunch" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SolarBeam, "SolarBeam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.LeafBlade, "LeafBlade" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PowerWhip, "PowerWhip" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Splash, "Splash" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Acid, "Acid" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.AirCutter, "AirCutter" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Hurricane, "Hurricane" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BrickBreak, "BrickBreak" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Cut, "Cut" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Swift, "Swift" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.HornAttack, "HornAttack" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Stomp, "Stomp" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Headbutt, "Headbutt" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.HyperFang, "HyperFang" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Slam, "Slam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BodySlam, "BodySlam" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Rest, "Rest" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.Struggle, "Struggle" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ScaldBlastoise, "ScaldBlastoise" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.HydroPumpBlastoise, "HydroPumpBlastoise" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.WrapGreen, "WrapGreen" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.WrapPink, "WrapPink" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FuryCutterFast, "FuryCutterFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BugBiteFast, "BugBiteFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BiteFast, "BiteFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SuckerPunchFast, "SuckerPunchFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.DragonBreathFast, "DragonBreathFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ThunderShockFast, "ThunderShockFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SparkFast, "SparkFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.LowKickFast, "LowKickFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.KarateChopFast, "KarateChopFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.EmberFast, "EmberFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.WingAttackFast, "WingAttackFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PeckFast, "PeckFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.LickFast, "LickFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ShadowClawFast, "ShadowClawFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.VineWhipFast, "VineWhipFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.RazorLeafFast, "RazorLeafFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MudShotFast, "MudShotFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.IceShardFast, "IceShardFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FrostBreathFast, "FrostBreathFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.QuickAttackFast, "QuickAttackFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ScratchFast, "ScratchFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.TackleFast, "TackleFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PoundFast, "PoundFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.CutFast, "CutFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PoisonJabFast, "PoisonJabFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.AcidFast, "AcidFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PsychoCutFast, "PsychoCutFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.RockThrowFast, "RockThrowFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MetalClawFast, "MetalClawFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BulletPunchFast, "BulletPunchFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.WaterGunFast, "WaterGunFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SplashFast, "SplashFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.WaterGunFastBlastoise, "WaterGunFastBlastoise" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.MudSlapFast, "MudSlapFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ZenHeadbuttFast, "ZenHeadbuttFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.ConfusionFast, "ConfusionFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.PoisonStingFast, "PoisonStingFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.BubbleFast, "BubbleFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FeintAttackFast, "FeintAttackFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.SteelWingFast, "SteelWingFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.FireFangFast, "FireFangFast" ),
+            new KeyValuePair<POGOProtos.Enums.PokemonMove, string> ( POGOProtos.Enums.PokemonMove.RockSmashFast, "RockSmashFast" )
+        };
+
         public string GetTranslation(TranslationString translationString, params object[] data)
         {
             var translation = _translationStrings.FirstOrDefault(t => t.Key.Equals(translationString)).Value;
@@ -550,13 +793,22 @@ namespace PoGo.NecroBot.Logic.Common
             return translation != default(string) ? translation : $"Translation for pokemon {id} is missing";
         }
 
-        public static Translation Load(ILogicSettings logicSettings)
+        public string GetPokemonMovesetTranslation( POGOProtos.Enums.PokemonMove move )
+        {
+            var translation = _pokemonMovesetTranslationStrings.FirstOrDefault( t => t.Key.Equals( move ) ).Value;
+            return translation != default( string ) ? translation : $"Translation for move {move} is missing";
+        }
+
+        public static Translation Load( ILogicSettings logicSettings )
+        {
+            return Load( logicSettings, new Translation() );
+        }
+
+        public static Translation Load(ILogicSettings logicSettings, Translation translations )
         {
             var translationsLanguageCode = logicSettings.TranslationLanguageCode;
             var translationPath = Path.Combine(logicSettings.GeneralConfigPath, "translations");
             var fullPath = Path.Combine(translationPath, "translation." + translationsLanguageCode + ".json");
-
-            Translation translations;
             if (File.Exists(fullPath))
             {
                 var input = File.ReadAllText(fullPath);

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -799,7 +799,12 @@ namespace PoGo.NecroBot.Logic.Common
             return translation != default( string ) ? translation : $"Translation for move {move} is missing";
         }
 
-        public static Translation Load(ILogicSettings logicSettings, Translation translations = new Translation() )
+        public static Translation Load( ILogicSettings logicSettings )
+        {
+            return Load( logicSettings, new Translation() );
+        }
+
+        public static Translation Load(ILogicSettings logicSettings, Translation translations )
         {
             var translationsLanguageCode = logicSettings.TranslationLanguageCode;
             var translationPath = Path.Combine(logicSettings.GeneralConfigPath, "translations");

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -71,6 +71,7 @@ namespace PoGo.NecroBot.Logic
 
     public interface ILogicSettings
     {
+        bool UseWebsocket { get; }
         bool CatchPokemon { get; }
         bool TransferWeakPokemon { get; }
         bool DisableHumanWalking { get; }

--- a/PoGo.NecroBot.Logic/Logging/Logger.cs
+++ b/PoGo.NecroBot.Logic/Logging/Logger.cs
@@ -105,6 +105,7 @@ namespace PoGo.NecroBot.Logic.Logging
         Egg = 11,
         Update = 12,
         Info = 13,
-        Debug = 14
+        New = 14,
+        Debug = 15,
     }
 }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -2,7 +2,9 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using PoGo.NecroBot.Logic.Common;
 using PoGo.NecroBot.Logic.Logging;
+using PoGo.NecroBot.Logic.State;
 using POGOProtos.Enums;
 using POGOProtos.Inventory.Item;
 using PokemonGo.RocketAPI;
@@ -35,70 +37,70 @@ namespace PoGo.NecroBot.Logic
         public string UseProxyUsername;
         public string UseProxyPassword;
 
-        public void Load(string path)
+        public void Load( string path )
         {
             try
             {
                 _filePath = path;
 
-                if (File.Exists(_filePath))
+                if( File.Exists( _filePath ) )
                 {
                     //if the file exists, load the settings
-                    var input = File.ReadAllText(_filePath);
+                    var input = File.ReadAllText( _filePath );
 
                     var settings = new JsonSerializerSettings();
-                    settings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
+                    settings.Converters.Add( new StringEnumConverter { CamelCaseText = true } );
 
-                    JsonConvert.PopulateObject(input, this, settings);
+                    JsonConvert.PopulateObject( input, this, settings );
                 }
                 else
                 {
-                    Save(_filePath);
+                    Save( _filePath );
                 }
             }
-            catch (JsonReaderException exception)
+            catch( JsonReaderException exception )
             {
-                if (exception.Message.Contains("Unexpected character") && exception.Message.Contains("PtcUsername"))
-                    Logger.Write("JSON Exception: You need to properly configure your PtcUsername using quotations.",
-                        LogLevel.Error);
-                else if (exception.Message.Contains("Unexpected character") && exception.Message.Contains("PtcPassword"))
+                if( exception.Message.Contains( "Unexpected character" ) && exception.Message.Contains( "PtcUsername" ) )
+                    Logger.Write( "JSON Exception: You need to properly configure your PtcUsername using quotations.",
+                        LogLevel.Error );
+                else if( exception.Message.Contains( "Unexpected character" ) && exception.Message.Contains( "PtcPassword" ) )
                     Logger.Write(
                         "JSON Exception: You need to properly configure your PtcPassword using quotations.",
-                        LogLevel.Error);
-                else if (exception.Message.Contains("Unexpected character") &&
-                         exception.Message.Contains("GoogleUsername"))
+                        LogLevel.Error );
+                else if( exception.Message.Contains( "Unexpected character" ) &&
+                         exception.Message.Contains( "GoogleUsername" ) )
                     Logger.Write(
                         "JSON Exception: You need to properly configure your GoogleUsername using quotations.",
-                        LogLevel.Error);
-                else if (exception.Message.Contains("Unexpected character") &&
-                         exception.Message.Contains("GooglePassword"))
+                        LogLevel.Error );
+                else if( exception.Message.Contains( "Unexpected character" ) &&
+                         exception.Message.Contains( "GooglePassword" ) )
                     Logger.Write(
                         "JSON Exception: You need to properly configure your GooglePassword using quotations.",
-                        LogLevel.Error);
+                        LogLevel.Error );
                 else
-                    Logger.Write("JSON Exception: " + exception.Message, LogLevel.Error);
+                    Logger.Write( "JSON Exception: " + exception.Message, LogLevel.Error );
             }
         }
 
-        public void Save(string path)
+        public void Save( string path )
         {
-            var output = JsonConvert.SerializeObject(this, Formatting.Indented,
-                new StringEnumConverter { CamelCaseText = true });
+            var output = JsonConvert.SerializeObject( this, Formatting.Indented,
+                new StringEnumConverter { CamelCaseText = true } );
 
-            var folder = Path.GetDirectoryName(path);
-            if (folder != null && !Directory.Exists(folder))
+            var folder = Path.GetDirectoryName( path );
+            if( folder != null && !Directory.Exists( folder ) )
             {
-                Directory.CreateDirectory(folder);
+                Directory.CreateDirectory( folder );
             }
 
-            File.WriteAllText(path, output);
+            File.WriteAllText( path, output );
         }
 
         public void Save()
         {
-            if (!string.IsNullOrEmpty(_filePath))
+            if( !string.IsNullOrEmpty( _filePath ) )
             {
-                Save(_filePath);
+                Save( _filePath );
             }
         }
     }
@@ -113,6 +115,7 @@ namespace PoGo.NecroBot.Logic
         public string ProfileConfigPath;
         [JsonIgnore]
         public string ProfilePath;
+
         [JsonIgnore]
         public bool isGui;
 
@@ -548,25 +551,29 @@ namespace PoGo.NecroBot.Logic
 
         public GlobalSettings()
         {
-            InitializePropertyDefaultValues(this);
+            InitializePropertyDefaultValues( this );
         }
 
-        public void InitializePropertyDefaultValues(object obj)
+        public void InitializePropertyDefaultValues( object obj )
         {
             FieldInfo[] fields = obj.GetType().GetFields();
 
-            foreach (FieldInfo field in fields)
+            foreach( FieldInfo field in fields )
             {
                 var d = field.GetCustomAttribute<DefaultValueAttribute>();
 
-                if (d != null)
-                    field.SetValue(obj, d.Value);
+                if( d != null )
+                    field.SetValue( obj, d.Value );
             }
         }
 
         public static GlobalSettings Default => new GlobalSettings();
 
-        public static GlobalSettings Load(string path)
+        public static GlobalSettings Load( string path )
+        {
+            return Load( path, false );
+        }
+        public static GlobalSettings Load( string path, bool boolSkipSave )
         {
             GlobalSettings settings = null;
             bool isGui = (AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(a => a.FullName.Contains("PoGo.NecroBot.GUI")) != null);
@@ -575,19 +582,19 @@ namespace PoGo.NecroBot.Logic
             var configFile = Path.Combine(profileConfigPath, "config.json");
             var shouldExit = false;
 
-            if (File.Exists(configFile))
+            if( File.Exists( configFile ) )
             {
                 try
                 {
                     //if the file exists, load the settings
-                    var input = File.ReadAllText(configFile);
+                    var input = File.ReadAllText( configFile );
 
                     var jsonSettings = new JsonSerializerSettings();
-                    jsonSettings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
+                    jsonSettings.Converters.Add( new StringEnumConverter { CamelCaseText = true } );
                     jsonSettings.ObjectCreationHandling = ObjectCreationHandling.Replace;
                     jsonSettings.DefaultValueHandling = DefaultValueHandling.Populate;
 
-                    settings = JsonConvert.DeserializeObject<GlobalSettings>(input, jsonSettings);
+                    settings = JsonConvert.DeserializeObject<GlobalSettings>( input, jsonSettings );
 
                     //This makes sure that existing config files dont get null values which lead to an exception
                     foreach (var filter in settings.PokemonsTransferFilter.Where(x => x.Value.KeepMinOperator == null))
@@ -602,40 +609,11 @@ namespace PoGo.NecroBot.Logic
                     {
                         filter.Value.MovesOperator = "or";
                     }
-
                 }
-                catch (JsonReaderException exception)
+                catch( JsonReaderException exception )
                 {
-                    Logger.Write("JSON Exception: " + exception.Message, LogLevel.Error);
+                    Logger.Write( "JSON Exception: " + exception.Message, LogLevel.Error );
                     return null;
-                }
-            }
-            else if (!isGui)
-            {
-                Logger.Write("This is your first start, would you like to begin setup? Y/N", LogLevel.Warning);
-
-                bool boolBreak = false;
-                settings = new GlobalSettings();
-
-                while (!boolBreak)
-                {
-                    string strInput = Console.ReadLine().ToLower();
-
-                    switch (strInput)
-                    {
-                        case "y":
-                            boolBreak = true;
-                            SetupSettings(settings);
-                            break;
-                        case "n":
-                            Logger.Write("Config/Auth file automatically generated and must be completed before continuing");
-                            boolBreak = true;
-                            shouldExit = true;
-                            break;
-                        default:
-                            Logger.Write("[INPUT ERROR] Error with input, please enter 'y' or 'n'", LogLevel.Error);
-                            continue;
-                    }
                 }
             }
             else
@@ -644,115 +622,209 @@ namespace PoGo.NecroBot.Logic
                 shouldExit = true;
             }
 
+
             settings.ProfilePath = profilePath;
             settings.ProfileConfigPath = profileConfigPath;
-            settings.GeneralConfigPath = Path.Combine(Directory.GetCurrentDirectory(), "config");
+            settings.GeneralConfigPath = Path.Combine( Directory.GetCurrentDirectory(), "config" );
             settings.isGui = isGui;
             settings.migratePercentages();
 
-            settings.Save(configFile);
-            settings.Auth.Load(Path.Combine(profileConfigPath, "auth.json"));
+            if( !boolSkipSave || !settings.AutoUpdate )
+            {
+                settings.Save( configFile );
+                settings.Auth.Load( Path.Combine( profileConfigPath, "auth.json" ) );
+            }
 
             return shouldExit ? null : settings;
         }
 
-        private static void SetupSettings(GlobalSettings settings)
+        public static bool PromptForSetup( ITranslation translator )
         {
-            SetupAccountType(settings);
-            SetupUserAccount(settings);
-            SetupConfig(settings);
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartPrompt, "Y", "N" ), LogLevel.Warning );
 
-            Logger.Write("### COMPLETED SETUP ###", LogLevel.None);
+            while( true )
+            {
+                string strInput = Console.ReadLine().ToLower();
+
+                switch( strInput )
+                {
+                    case "y":
+                        return true;
+                    case "n":
+                        Logger.Write( translator.GetTranslation( TranslationString.FirstStartAutoGenSettings ) );
+                        return false;
+                    default:
+                        Logger.Write( translator.GetTranslation( TranslationString.PromptError, "Y", "N" ), LogLevel.Error );
+                        continue;
+                }
+            }
+        }
+        
+        public static Session SetupSettings( Session session, GlobalSettings settings, String configPath )
+        {
+            Session newSession = SetupTranslationCode( session, session.Translation, settings );
+
+            SetupAccountType( newSession.Translation, settings );
+            SetupUserAccount( newSession.Translation, settings );
+            SetupConfig( newSession.Translation, settings );
+            SaveFiles( settings, configPath );
+
+            Logger.Write( session.Translation.GetTranslation( TranslationString.FirstStartSetupCompleted ), LogLevel.None );
+
+            return newSession;
         }
 
-        private static void SetupAccountType(GlobalSettings settings)
+        private static Session SetupTranslationCode( Session session, ITranslation translator, GlobalSettings settings )
         {
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartLanguagePrompt, "Y", "N" ), LogLevel.None );
             string strInput;
-            Logger.Write("### Setting up new USER ACCOUNT ###", LogLevel.None);
-            Logger.Write("Please choose an account type: google/ptc");
 
-            while (true)
+            bool boolBreak = false;
+            while( !boolBreak )
             {
                 strInput = Console.ReadLine().ToLower();
 
-                switch (strInput)
+                switch( strInput )
+                {
+                    case "y":
+                        boolBreak = true;
+                        break;
+                    case "n":
+                        return session;
+                    default:
+                        Logger.Write( translator.GetTranslation( TranslationString.PromptError, "y", "n" ), LogLevel.Error );
+                        continue;
+                }
+            }
+
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartLanguageCodePrompt ) );
+            strInput = Console.ReadLine();
+
+            settings.TranslationLanguageCode = strInput;
+            session = new Session( new ClientSettings( settings ), new LogicSettings( settings ) );
+            translator = session.Translation;
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartLanguageConfirm, strInput ) );
+
+            return session;
+        }
+
+
+        private static void SetupAccountType( ITranslation translator, GlobalSettings settings )
+        {
+            string strInput;
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupAccount ), LogLevel.None );
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupTypePrompt, "google", "ptc" ) );
+
+            while( true )
+            {
+                strInput = Console.ReadLine().ToLower();
+
+                switch( strInput )
                 {
                     case "google":
                         settings.Auth.AuthType = AuthType.Google;
-                        Logger.Write("Chosen Account Type: GOOGLE");
+                        Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupTypeConfirm, "GOOGLE" ) );
                         return;
                     case "ptc":
                         settings.Auth.AuthType = AuthType.Ptc;
-                        Logger.Write("Chosen Account Type: PTC");
+                        Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupTypeConfirm, "PTC" ) );
                         return;
                     default:
-                        Logger.Write("[ERROR] submitted an incorrect account type, please choose 'google' or 'ptc'", LogLevel.Error);
+                        Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupTypePromptError, "google", "ptc" ), LogLevel.Error );
                         break;
                 }
             }
         }
 
-        private static void SetupUserAccount(GlobalSettings settings)
+        private static void SetupUserAccount( ITranslation translator, GlobalSettings settings )
         {
-            Console.WriteLine("");
-            Logger.Write("Please enter a Username", LogLevel.None);
+            Console.WriteLine( "" );
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupUsernamePrompt ), LogLevel.None );
             string strInput = Console.ReadLine();
 
-            if (settings.Auth.AuthType == AuthType.Google)
+            if( settings.Auth.AuthType == AuthType.Google )
                 settings.Auth.GoogleUsername = strInput;
             else
                 settings.Auth.PtcUsername = strInput;
-            Logger.Write("Accepted username: " + strInput);
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupUsernameConfirm, strInput ) );
 
-            Console.WriteLine("");
-            Logger.Write("Please enter a Password", LogLevel.None);
+            Console.WriteLine( "" );
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupPasswordPrompt ), LogLevel.None );
             strInput = Console.ReadLine();
 
-            if (settings.Auth.AuthType == AuthType.Google)
+            if( settings.Auth.AuthType == AuthType.Google )
                 settings.Auth.GooglePassword = strInput;
             else
                 settings.Auth.PtcPassword = strInput;
-            Logger.Write("Accepted password: " + strInput);
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupPasswordConfirm, strInput ) );
 
-            Logger.Write("### User Account Completed ###\n", LogLevel.None);
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartAccountCompleted ), LogLevel.None );
         }
 
-        private static void SetupConfig(GlobalSettings settings)
+        private static void SetupConfig( ITranslation translator, GlobalSettings settings )
         {
-            Logger.Write("### Setting Default Position ###", LogLevel.None);
-            Logger.Write("Please enter a Latitude (Right click to paste)");
-            while (true)
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartDefaultLocationPrompt, "Y", "N" ), LogLevel.None );
+
+            bool boolBreak = false;
+            while( !boolBreak )
+            {
+                string strInput = Console.ReadLine().ToLower();
+
+                switch( strInput )
+                {
+                    case "y":
+                        boolBreak = true;
+                        break;
+                    case "n":
+                        Logger.Write( translator.GetTranslation( TranslationString.FirstStartDefaultLocationSet ) );
+                        return;
+                    default:
+                        // PROMPT ERROR \\
+                        Logger.Write( translator.GetTranslation( TranslationString.PromptError, "y", "n" ), LogLevel.Error );
+                        continue;
+                }
+            }
+
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartDefaultLocation ), LogLevel.None );
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupDefaultLatPrompt ) );
+            while( true )
             {
                 try
                 {
-                    double dblInput = double.Parse(Console.ReadLine());
+                    double dblInput = double.Parse( Console.ReadLine() );
                     settings.DefaultLatitude = dblInput;
-                    Logger.Write("Lattitude accepted: " + dblInput);
+                    Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupDefaultLatConfirm, dblInput ) );
                     break;
                 }
-                catch (FormatException)
+                catch( FormatException )
                 {
-                    Logger.Write("[ERROR] Please input only a VALUE for example: " + settings.DefaultLatitude, LogLevel.Error);
+                    Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupDefaultLocationError, settings.DefaultLatitude, LogLevel.Error ) );
                     continue;
                 }
             }
 
-            Logger.Write("Please enter a Longitude (Right click to paste)");
-            while (true)
+            Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupDefaultLongPrompt ) );
+            while( true )
             {
                 try
                 {
-                    double dblInput = double.Parse(Console.ReadLine());
+                    double dblInput = double.Parse( Console.ReadLine() );
                     settings.DefaultLongitude = dblInput;
-                    Logger.Write("Longitude accepted: " + dblInput);
+                    Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupDefaultLongConfirm, dblInput ) );
                     break;
                 }
-                catch (FormatException)
+                catch( FormatException )
                 {
-                    Logger.Write("[ERROR] Please input only a VALUE for example: " + settings.DefaultLongitude, LogLevel.Error);
+                    Logger.Write( translator.GetTranslation( TranslationString.FirstStartSetupDefaultLocationError, settings.DefaultLongitude, LogLevel.Error ) );
                     continue;
                 }
             }
+        }
+
+        private static void SaveFiles( GlobalSettings settings, String configFile )
+        {
+            settings.Save( configFile );
+            settings.Auth.Load( Path.Combine( settings.ProfileConfigPath, "auth.json" ) );
         }
 
 
@@ -761,17 +833,17 @@ namespace PoGo.NecroBot.Logic
         /// </summary>
         private void migratePercentages()
         {
-            if (EvolveKeptPokemonsAtStorageUsagePercentage <= 1.0)
+            if( EvolveKeptPokemonsAtStorageUsagePercentage <= 1.0 )
             {
                 EvolveKeptPokemonsAtStorageUsagePercentage *= 100.0f;
             }
-            if (RecycleInventoryAtUsagePercentage <= 1.0)
+            if( RecycleInventoryAtUsagePercentage <= 1.0 )
             {
                 RecycleInventoryAtUsagePercentage *= 100.0f;
             }
         }
 
-        public void Save(string fullPath)
+        public void Save( string fullPath )
         {
             var jsonSerializeSettings = new JsonSerializerSettings
             {
@@ -780,15 +852,15 @@ namespace PoGo.NecroBot.Logic
                 Converters = new JsonConverter[] { new StringEnumConverter { CamelCaseText = true } }
             };
 
-            var output = JsonConvert.SerializeObject(this, jsonSerializeSettings);
+            var output = JsonConvert.SerializeObject( this, jsonSerializeSettings );
 
-            var folder = Path.GetDirectoryName(fullPath);
-            if (folder != null && !Directory.Exists(folder))
+            var folder = Path.GetDirectoryName( fullPath );
+            if( folder != null && !Directory.Exists( folder ) )
             {
-                Directory.CreateDirectory(folder);
+                Directory.CreateDirectory( folder );
             }
 
-            File.WriteAllText(fullPath, output);
+            File.WriteAllText( fullPath, output );
         }
     }
 
@@ -798,7 +870,7 @@ namespace PoGo.NecroBot.Logic
         private readonly Random _rand = new Random();
         private readonly GlobalSettings _settings;
 
-        public ClientSettings(GlobalSettings settings)
+        public ClientSettings( GlobalSettings settings )
         {
             _settings = settings;
         }
@@ -859,7 +931,7 @@ namespace PoGo.NecroBot.Logic
         {
             get
             {
-                return _settings.DefaultLatitude + _rand.NextDouble() * ((double)_settings.MaxSpawnLocationOffset / 111111);
+                return _settings.DefaultLatitude + _rand.NextDouble() * ( (double) _settings.MaxSpawnLocationOffset / 111111 );
             }
 
             set { _settings.DefaultLatitude = value; }
@@ -871,7 +943,7 @@ namespace PoGo.NecroBot.Logic
             {
                 return _settings.DefaultLongitude +
                        _rand.NextDouble() *
-                       ((double)_settings.MaxSpawnLocationOffset / 111111 / Math.Cos(_settings.DefaultLatitude));
+                       ( (double) _settings.MaxSpawnLocationOffset / 111111 / Math.Cos( _settings.DefaultLatitude ) );
             }
 
             set { _settings.DefaultLongitude = value; }
@@ -917,7 +989,8 @@ namespace PoGo.NecroBot.Logic
     {
         private readonly GlobalSettings _settings;
 
-        public LogicSettings(GlobalSettings settings)
+        public LogicSettings( GlobalSettings settings )
+
         {
             _settings = settings;
         }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -123,6 +123,9 @@ namespace PoGo.NecroBot.Logic
         public bool AutoUpdate;
         [DefaultValue(true)]
         public bool TransferConfigAndAuthOnUpdate;
+        //websockets
+        [DefaultValue(false)]
+        public bool UseWebsocket;
         //pressakeyshit
         [DefaultValue(false)]
         public bool StartupWelcomeDelay;
@@ -566,7 +569,7 @@ namespace PoGo.NecroBot.Logic
         public static GlobalSettings Load(string path)
         {
             GlobalSettings settings = null;
-            bool isGui = (AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName.Contains("PoGo.NecroBot.GUI")).SingleOrDefault() != null);
+            bool isGui = (AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(a => a.FullName.Contains("PoGo.NecroBot.GUI")) != null);
             var profilePath = Path.Combine(Directory.GetCurrentDirectory(), path);
             var profileConfigPath = Path.Combine(profilePath, "config");
             var configFile = Path.Combine(profileConfigPath, "config.json");
@@ -924,6 +927,7 @@ namespace PoGo.NecroBot.Logic
         public string GeneralConfigPath => _settings.GeneralConfigPath;
         public bool AutoUpdate => _settings.AutoUpdate;
         public bool TransferConfigAndAuthOnUpdate => _settings.TransferConfigAndAuthOnUpdate;
+        public bool UseWebsocket => _settings.UseWebsocket;
         public bool CatchPokemon => _settings.CatchPokemon;
         public bool TransferWeakPokemon => _settings.TransferWeakPokemon;
         public bool DisableHumanWalking => _settings.DisableHumanWalking;

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -568,12 +568,8 @@ namespace PoGo.NecroBot.Logic
         }
 
         public static GlobalSettings Default => new GlobalSettings();
-
-        public static GlobalSettings Load( string path )
-        {
-            return Load( path, false );
-        }
-        public static GlobalSettings Load( string path, bool boolSkipSave )
+        
+        public static GlobalSettings Load( string path, bool boolSkipSave = false )
         {
             GlobalSettings settings = null;
             bool isGui = (AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(a => a.FullName.Contains("PoGo.NecroBot.GUI")) != null);

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Linq;
 using PoGo.NecroBot.Logic.Common;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.Logging;
+using System.Collections.Generic;
 
 #endregion
 
@@ -37,10 +38,10 @@ namespace PoGo.NecroBot.Logic.State
 
             await CleanupOldFiles();
             var autoUpdate = session.LogicSettings.AutoUpdate;
-            var needupdate = IsLatest();
-            if (!needupdate || !autoUpdate)
+            var isLatest = IsLatest();
+            if ( isLatest || !autoUpdate )
             {
-                if (!needupdate)
+                if ( isLatest )
                 {
                     session.EventDispatcher.Send(new UpdateEvent
                     {
@@ -55,7 +56,30 @@ namespace PoGo.NecroBot.Logic.State
                 });
 
                 return new LoginState();
+            } else
+            {
+                Logger.Write( "New update detected, would you like to update? Y/N", LogLevel.Update );
+
+                bool boolBreak = false;
+                while( !boolBreak )
+                {
+                    string strInput = Console.ReadLine().ToLower();
+
+                    switch( strInput )
+                    {
+                        case "y":
+                            boolBreak = true;
+                            break;
+                        case "n":
+                            Logger.Write( "Update Skipped", LogLevel.Update );
+                            return new LoginState();
+                        default:
+                            Logger.Write( session.Translation.GetTranslation( TranslationString.PromptError, "Y", "N" ), LogLevel.Error );
+                            continue;
+                    }
+                }
             }
+
             session.EventDispatcher.Send(new UpdateEvent
             {
                 Message = session.Translation.GetTranslation(TranslationString.DownloadingUpdate)
@@ -95,11 +119,9 @@ namespace PoGo.NecroBot.Logic.State
                 Message = session.Translation.GetTranslation(TranslationString.UpdateFinished)
             });
 
-            if (TransferConfig(baseDir, session))
-                session.EventDispatcher.Send(new UpdateEvent
-                {
-                    Message = session.Translation.GetTranslation(TranslationString.FinishedTransferringConfig)
-                });
+            if( TransferConfig( baseDir, session ) )
+                Utils.ErrorHandler.ThrowFatalError( session.Translation.GetTranslation( TranslationString.FinishedTransferringConfig ), 5, LogLevel.Update );
+            
 
             await Task.Delay(2000, cancellationToken);
 
@@ -167,29 +189,27 @@ namespace PoGo.NecroBot.Logic.State
         }
 
 
-        public bool IsLatest()
+        public static bool IsLatest()
         {
             try
             {
                 var regex = new Regex(@"\[assembly\: AssemblyVersion\(""(\d{1,})\.(\d{1,})\.(\d{1,})""\)\]");
                 var match = regex.Match(DownloadServerVersion());
-
+                
                 if (!match.Success)
                     return false;
 
                 var gitVersion = new Version($"{match.Groups[1]}.{match.Groups[2]}.{match.Groups[3]}");
                 RemoteVersion = gitVersion;
                 if (gitVersion >= Assembly.GetExecutingAssembly().GetName().Version)
-                {
-                    return true;
-                }
+                    return false;
             }
             catch (Exception)
             {
-                return true; //better than just doing nothing when git server down
+                return false; //better than just doing nothing when git server down
             }
 
-            return false;
+            return true;
         }
 
         public static bool MoveAllFiles(string sourceFolder, string destFolder)
@@ -248,30 +268,84 @@ namespace PoGo.NecroBot.Logic.State
             var newConf = GetJObject(Path.Combine(configDir, "config.json"));
             var newAuth = GetJObject(Path.Combine(configDir, "auth.json"));
 
-            TransferJson(oldConf, newConf);
+            List<JProperty> lstNewOptions = TransferJson(oldConf, newConf);
             TransferJson(oldAuth, newAuth);
-
+            
             File.WriteAllText(Path.Combine(configDir, "config.json"), newConf.ToString());
             File.WriteAllText(Path.Combine(configDir, "auth.json"), newAuth.ToString());
+
+            if( lstNewOptions != null && lstNewOptions.Count > 0 )
+            {
+                Console.Write( "\n" );
+                Logger.Write( "### New Options found ###", LogLevel.New );
+
+                foreach( JProperty prop in lstNewOptions )
+                    Logger.Write( prop.ToString(), LogLevel.New );
+
+                Logger.Write( "Would you like to open the Config file? Y/N", LogLevel.Info );
+                
+                while( true )
+                {
+                    string strInput = Console.ReadLine().ToLower();
+
+                    switch( strInput )
+                    {
+                        case "y":
+                            Process.Start( Path.Combine( configDir, "config.json" ) );
+                            return true;
+                        case "n":
+                            return true;
+                        default:
+                            Logger.Write( session.Translation.GetTranslation( TranslationString.PromptError, "y", "n" ), LogLevel.Error );
+                            continue;
+                    }
+                }
+            }
+            
             return true;
         }
 
-        private static void TransferJson(JObject oldFile, JObject newFile)
+        private static List<JProperty> TransferJson(JObject oldFile, JObject newFile)
         {
             try
             {
-                foreach (var newProperty in newFile.Properties())
+                // Figuring out the best method to detect new settings \\
+                List<JProperty> lstNewOptions = new List<JProperty>();
+                
+                foreach( var newProperty in newFile.Properties() )
+                {
+                    bool boolFound = false;
+                    
+                    foreach( var oldProperty in oldFile.Properties() )
+                    {
+                        if( newProperty.Name.Equals( oldProperty.Name ) )
+                        {
+                            boolFound = true;
+                            newFile[ newProperty.Name ] = oldProperty.Value;
+                            break;
+                        }
+                    }
+
+                    if( !boolFound )
+                        lstNewOptions.Add( newProperty );
+                }
+
+                return lstNewOptions;
+
+                /*foreach (var newProperty in newFile.Properties())
                     foreach (var oldProperty in oldFile.Properties())
                         if (newProperty.Name.Equals(oldProperty.Name))
                         {
                             newFile[newProperty.Name] = oldProperty.Value;
                             break;
-                        }
+                        }*/
             }
-            catch
+            catch( Exception error )
             {
-                // ignored
+                Console.WriteLine( error.Message );
             }
+
+            return null;
         }
 
         public static bool UnpackFile(string sourceTarget, string destPath)

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -206,7 +206,7 @@ namespace PoGo.NecroBot.Logic.State
             }
             catch (Exception)
             {
-                return false; //better than just doing nothing when git server down
+                return true; //better than just doing nothing when git server down
             }
 
             return true;

--- a/PoGo.NecroBot.Logic/StatisticsAggregator.cs
+++ b/PoGo.NecroBot.Logic/StatisticsAggregator.cs
@@ -48,7 +48,7 @@ namespace PoGo.NecroBot.Logic
 
         public void HandleEvent(TransferPokemonEvent evt, ISession session)
         {
-            _stats.TotalPokemonsTransfered++;
+            _stats.TotalPokemonTransferred++;
             _stats.Dirty(session.Inventory);
         }
 

--- a/PoGo.NecroBot.Logic/Utils/ErrorHandler.cs
+++ b/PoGo.NecroBot.Logic/Utils/ErrorHandler.cs
@@ -16,7 +16,8 @@ namespace PoGo.NecroBot.Logic.Utils
         /// <param name="timeout">The total seconds the messag will display before shutting down</param>
         public static void ThrowFatalError( string strMessage, int timeout, LogLevel level )
         {
-            Logger.Write( strMessage, level );
+            if( strMessage != null)
+                Logger.Write( strMessage, level );
 
             Console.Write( "Ending Application... " );
 

--- a/PoGo.NecroBot.Logic/Utils/Statistics.cs
+++ b/PoGo.NecroBot.Logic/Utils/Statistics.cs
@@ -23,13 +23,13 @@ namespace PoGo.NecroBot.Logic.Utils
     public class Statistics
     {
         private readonly DateTime _initSessionDateTime = DateTime.Now;
-
+        
         private StatsExport _exportStats;
         private string _playerName;
         public int TotalExperience;
         public int TotalItemsRemoved;
         public int TotalPokemons;
-        public int TotalPokemonsTransfered;
+        public int TotalPokemonTransferred;
         public int TotalStardust;
         public int LevelForRewards = -1;
 
@@ -114,9 +114,10 @@ namespace PoGo.NecroBot.Logic.Utils
         {
             var xpStats = string.Format(xpTemplate, _exportStats.Level, _exportStats.HoursUntilLvl,
                 _exportStats.MinutesUntilLevel, _exportStats.CurrentXp, _exportStats.LevelupXp);
+
             return string.Format(template, _playerName, FormatRuntime(), xpStats, TotalExperience/GetRuntime(),
                 TotalPokemons/GetRuntime(),
-                TotalStardust, TotalPokemonsTransfered, TotalItemsRemoved);
+                TotalStardust, TotalPokemonTransferred, TotalItemsRemoved);
         }
 
         public static int GetXpDiff(int level)


### PR DESCRIPTION
_Resubmitted #2711 with fresh clone_

**CHANGELOG:**
- Added a new method to pull the system translation when new configs are created. It will then ask the user if they would like to enter a new language code (And then build the config)

- Now asks the user if they would like to download/install a new update (When there is one) and will display any new options added in the version.

- Implemented functions to allow for the translation of pokemon moves

- If the user is updating the bot and new options are added, ask the user if they would like to open the config file to view the new additions.

- Added a low level killswitch to disable the bot and print a notification for the reason. This is only for situations whereby the bot may be broken. **This was made extremely quickly and I believe there should be better implementation of this idea**

_This commit has been tested by only two users, one on an english system, another on a french system. Multiple logical processes were tested however there may still be issues to be found_

**Credits to @Oolaruu for the ideas**