### PR TITLE
Only catch pokemon that are greater CP than current pokemon in bag

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -182,5 +182,6 @@ namespace PoGo.NecroBot.Logic
         SnipeSettings PokemonToSnipe { get; }
 
         bool StartupWelcomeDelay { get; }
+        bool OnlyCatchHigherCpThanCurrentMinimum { get; }
     }
 }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -256,6 +256,15 @@ namespace PoGo.NecroBot.Logic
                 .FirstOrDefault();
         }
 
+        public async Task<PokemonData> GetLowestPokemonOfTypeByCp(PokemonId pokemon)
+        {
+            var myPokemon = await GetPokemons();
+            var pokemons = myPokemon.ToList();
+            return pokemons.Where(x => x.PokemonId == pokemon)
+                .OrderBy(x => x.Cp)
+                .FirstOrDefault();
+        }
+
         public async Task<IEnumerable<PokemonData>> GetHighestsCp(int limit)
         {
             var myPokemon = await GetPokemons();

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -335,6 +335,8 @@ namespace PoGo.NecroBot.Logic
         public bool UsePokemonSniperFilterOnly;
         [DefaultValue(14251)]
         public int WebSocketPort;
+        [DefaultValue(false)]
+        public bool OnlyCatchHigherCpThanCurrentMinimum;
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
         {
             new KeyValuePair<ItemId, int>(ItemId.ItemUnknown, 0),
@@ -1074,6 +1076,7 @@ namespace PoGo.NecroBot.Logic
         public ICollection<PokemonId> PokemonsNotToCatch => _settings.PokemonsToIgnore;
         public ICollection<PokemonId> PokemonToUseMasterball => _settings.PokemonToUseMasterball;
         public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter => _settings.PokemonsTransferFilter;
+        public bool OnlyCatchHigherCpThanCurrentMinimum => _settings.OnlyCatchHigherCpThanCurrentMinimum;
         public bool StartupWelcomeDelay => _settings.StartupWelcomeDelay;
         public bool SnipeAtPokestops => _settings.SnipeAtPokestops;
         public int MinPokeballsToSnipe => _settings.MinPokeballsToSnipe;

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -45,6 +45,16 @@ namespace PoGo.NecroBot.Logic.Tasks
                     ? encounter.WildPokemon?.PokemonData
                     : encounter?.PokemonData);
 
+            if (session.LogicSettings.OnlyCatchHigherCpThanCurrentMinimum)
+            {
+                var pok = await session.Inventory.GetLowestPokemonOfTypeByCp(pokemon.PokemonId);
+                if (pok != null)
+                {
+                    if (pok.Cp > pokemonCp)
+                        return;
+                }
+            }
+
             // Determine whether to use berries or not
             if ((session.LogicSettings.UseBerriesOperator.ToLower().Equals("and") &&
                     pokemonIv >= session.LogicSettings.UseBerriesMinIv &&


### PR DESCRIPTION
Added a new flag "OnlyCatchHigherCpThanCurrentMinimum". Setting it to true will only catch pokemon that are above CP than your current same pokemon in inventory. Default Value is false.
It helps prevent having so much candy for common pokemon.