### PR TITLE
Limit pokemon Lat & Long to 6 decimals

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -183,7 +183,7 @@ namespace PoGo.NecroBot.CLI
                pokemonCaptureEvent.Level, pokemonCaptureEvent.Cp, pokemonCaptureEvent.MaxCp, pokemonCaptureEvent.Perfection.ToString("0.00"), pokemonCaptureEvent.Probability,
                pokemonCaptureEvent.Distance.ToString("F2"),
                returnRealBallName(pokemonCaptureEvent.Pokeball), pokemonCaptureEvent.BallAmount,
-               pokemonCaptureEvent.Exp, familyCandies, pokemonCaptureEvent.Latitude, pokemonCaptureEvent.Longitude);
+               pokemonCaptureEvent.Exp, familyCandies, pokemonCaptureEvent.Latitude.ToString("0.000000"), pokemonCaptureEvent.Longitude.ToString("0.000000"));
                Logger.Write(message, LogLevel.Caught);
             }
             else
@@ -192,7 +192,7 @@ namespace PoGo.NecroBot.CLI
                 pokemonCaptureEvent.Level, pokemonCaptureEvent.Cp, pokemonCaptureEvent.MaxCp, pokemonCaptureEvent.Perfection.ToString("0.00"), pokemonCaptureEvent.Probability,
                 pokemonCaptureEvent.Distance.ToString("F2"),
                 returnRealBallName(pokemonCaptureEvent.Pokeball), pokemonCaptureEvent.BallAmount,
-                pokemonCaptureEvent.Latitude, pokemonCaptureEvent.Longitude);
+                pokemonCaptureEvent.Latitude.ToString("0.000000"), pokemonCaptureEvent.Longitude.ToString("0.000000"));
                 Logger.Write(message, LogLevel.Flee);
             }
 


### PR DESCRIPTION
Limit pokemonCaptureEvent Latitude & Longitude to 6 decimal places in log.