### PR TITLE
Change  UseBerriesOperator  to OR for better catch

### DIFF
--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -305,7 +305,7 @@ namespace PoGo.NecroBot.Logic
         public float UseBerriesMinIv;
         [DefaultValue(0.20)]
         public double UseBerriesBelowCatchProbability;
-        [DefaultValue("and")]
+        [DefaultValue("or")]
         public string UseBerriesOperator;
         //snipe
         [DefaultValue(true)]


### PR DESCRIPTION
change the default setting for UseBerriesOperator from AND to OR to use more berries to have more sucefull catches and less Recycling