### PR TITLE
Fix for realistic height

### DIFF
--- a/PoGo.NecroBot.Logic/Utils/LocationUtils.cs
+++ b/PoGo.NecroBot.Logic/Utils/LocationUtils.cs
@@ -36,7 +36,20 @@ namespace PoGo.NecroBot.Logic.Utils
             var sr = new StreamReader(response.GetResponseStream() ?? new MemoryStream()).ReadToEnd();
 
             var json = JObject.Parse(sr);
-            return (double)json.SelectToken("results[0].elevation");
+
+            if(json.SelectToken("results[0].elevation") != null)
+            {
+                return (double)json.SelectToken("results[0].elevation");
+            }
+            else // if google not working
+            {
+                Random random = new Random();
+                double maximum = 11.0f;
+                double minimum = 8.6f;
+                double return1 = random.NextDouble() * (maximum - minimum) + minimum;
+
+                return return1;
+            }
         }
 
         public static GeoCoordinate CreateWaypoint(GeoCoordinate sourceLocation, double distanceInMeters,


### PR DESCRIPTION
If google have too mutch request they send notting ...

and make a crash
` System.ArgumentNullException: Value cannot be null.
Parameter name: value
   at Newtonsoft.Json.Linq.JToken.EnsureValue(JToken value)
   at Newtonsoft.Json.Linq.JToken.op_Explicit(JToken value)
   at PoGo.NecroBot.Logic.Utils.LocationUtils.getElevation(Double lat, Double lon) in C:\Users\ciamo\Source\Repos\NecroBot\PoGo.NecroBot.Logic\Utils\LocationUtils.cs:line 36
   at PoGo.NecroBot.Logic.Utils.LocationUtils.CreateWaypoint(GeoCoordinate sourceLocation, Double distanceInMeters, Double bearingDegrees) in C:\Users\ciamo\Source\Repos\NecroBot\PoGo.NecroBot.Logic\Utils\LocationUtils.cs:line 65
   at PoGo.NecroBot.Logic.Navigation.<Move>d__3.MoveNext() in C:\Users\ciamo\Source\Repos\NecroBot\PoGo.NecroBot.Logic\Navigation.cs:line 42
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   at PoGo.NecroBot.Logic.Tasks.FarmPokestopsTask.<Execute>d__2.MoveNext() in C:\Users\ciamo\Source\Repos\NecroBot\PoGo.NecroBot.Logic\Tasks\FarmPokestopsTask.cs:line 82
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   at PoGo.NecroBot.Logic.State.FarmState.<Execute>d__0.MoveNext() in C:\Users\ciamo\Source\Repos\NecroBot\PoGo.NecroBot.Logic\State\FarmState.cs:line 66
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at PoGo.NecroBot.Logic.State.StateMachine.<Start>d__3.MoveNext() in C:\Users\ciamo\Source\Repos\NecroBot\PoGo.NecroBot.Logic\State\StateMachine.cs:line 36`

so this is a fast "fix" for use random height