### PR TITLE
Prevent IOException from crashing bot, occurs when trying redirecting output stream

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -154,7 +154,11 @@ namespace PoGo.NecroBot.CLI
             machine.AsyncStart(new VersionCheckState(), session);
             if (session.LogicSettings.UseSnipeLocationServer)
                 SnipePokemonTask.AsyncStart(session);
-            Console.Clear();
+
+            try {
+                Console.Clear();
+            }
+            catch (IOException) { }
 
             QuitEvent.WaitOne();
         }

--- a/PoGo.NecroBot.CLI/Resources/ProgressBar.cs
+++ b/PoGo.NecroBot.CLI/Resources/ProgressBar.cs
@@ -23,36 +23,40 @@ namespace PoGo.NecroBot.CLI.Resources
 
         public static void fill(int amt, ConsoleColor barColor = ConsoleColor.Red)
         {
-            Console.ForegroundColor = barColor;
-            Console.CursorLeft = 0+leftOffset;
-            Console.Write("[");
-            Console.CursorLeft = 47+leftOffset;
-            Console.Write("]");
-            Console.CursorLeft = 1 + leftOffset;
-            float segment = 45.5f / total;
+            try
+            {
+                Console.ForegroundColor = barColor;
+                Console.CursorLeft = 0 + leftOffset;
+                Console.Write("[");
+                Console.CursorLeft = 47 + leftOffset;
+                Console.Write("]");
+                Console.CursorLeft = 1 + leftOffset;
+                float segment = 45.5f / total;
 
-            int pos = 1 + leftOffset;
-            for (int i = 0; i < segment * amt; i++)
-            {
-                Console.BackgroundColor = barColor;
-                Console.CursorLeft = pos++;
-                Console.Write(" ");
-            }
-            
-            for (int i = pos; i <= (46+leftOffset-2); i++)
-            {
+                int pos = 1 + leftOffset;
+                for (int i = 0; i < segment * amt; i++)
+                {
+                    Console.BackgroundColor = barColor;
+                    Console.CursorLeft = pos++;
+                    Console.Write(" ");
+                }
+
+                for (int i = pos; i <= (46 + leftOffset - 2); i++)
+                {
+                    Console.BackgroundColor = ConsoleColor.Black;
+                    Console.CursorLeft = pos++;
+                    Console.Write(" ");
+                }
+
+                Console.CursorLeft = 50 + leftOffset;
                 Console.BackgroundColor = ConsoleColor.Black;
-                Console.CursorLeft = pos++;
-                Console.Write(" ");
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write(amt.ToString() + "%");
+
+                if (amt == total)
+                    Console.Write(Environment.NewLine);
             }
-
-            Console.CursorLeft = 50 + leftOffset;
-            Console.BackgroundColor = ConsoleColor.Black;
-            Console.ForegroundColor = ConsoleColor.White;
-            Console.Write(amt.ToString() + "%");
-
-            if (amt == total)
-                Console.Write(Environment.NewLine);
+            catch (System.IO.IOException) { }
         }
     }
 }


### PR DESCRIPTION
If you try to redirect the output stream of the program and are not actually running it the program directly, you end up getting an IOException saying invalid handle and crashing the bot.

This occurs because of the use of CursorLeft and Clear console functions.

Catching the exception prevents the bot from crashing in the case that the progress bar is not able to load because the output stream is being redirected.