### PR TITLE
Changed color for CatchEscape and CatchFlee events from red to yellow…

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleLogger.cs
+++ b/PoGo.NecroBot.CLI/ConsoleLogger.cs
@@ -83,7 +83,7 @@ namespace PoGo.NecroBot.CLI
                     Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] ({LoggingStrings.Pkmn}) {message}");
                     break;
                 case LogLevel.Flee:
-                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.ForegroundColor = ConsoleColor.Yellow;
                     Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] ({LoggingStrings.Pkmn}) {message}");
                     break;
                 case LogLevel.Transfer:


### PR DESCRIPTION
… to be less aggressive. Red should only be used for errors.

![catchescapefleeyellow](https://cloud.githubusercontent.com/assets/17240204/17467049/17aafdc2-5d1a-11e6-9a72-bbb45439dd4f.PNG)
