### PR TITLE
Update ConsoleLogger.cs

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleLogger.cs
+++ b/PoGo.NecroBot.CLI/ConsoleLogger.cs
@@ -83,7 +83,7 @@ namespace PoGo.NecroBot.CLI
                     Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] ({LoggingStrings.Pkmn}) {message}");
                     break;
                 case LogLevel.Flee:
-                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.ForegroundColor = ConsoleColor.DarkYellow;
                     Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] ({LoggingStrings.Pkmn}) {message}");
                     break;
                 case LogLevel.Transfer:


### PR DESCRIPTION
Change color (currently red) of Fleeing pokemon message in logger, to something less alarming like yellow/orange.