### PR TITLE
Fixed the amount of pokemon to evolve

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -193,7 +193,7 @@ namespace PoGo.NecroBot.Logic
                     settings.EvolutionIds.Count != 0)
                 {
                     var candiesToUse = familyCandy.Candy_ + inStorage;
-                    var possibleCountToEvolve = (candiesToUse / settings.CandyToEvolve;
+                    var possibleCountToEvolve = candiesToUse / settings.CandyToEvolve;
                     amountToKeepInStorage = Math.Max(amountToKeepInStorage, possibleCountToEvolve);
                 }
                

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -192,11 +192,6 @@ namespace PoGo.NecroBot.Logic
                     settings.CandyToEvolve > 0 &&
                     settings.EvolutionIds.Count != 0)
                 {
-                    // It does not matter if you transfer or evolve the pokemon
-                    // You always get 1 candy back
-                    // The amount of possible evolves is the amount of candies of that family
-                    // Combined with the amount of pokemon divided by the candies needed to evolve
-                    // ( FAMILY_CANDY + POKEMON_IN_STORAGE ) / CANDY_TO_EVOLVE
                     var candiesToUse = familyCandy.Candy_ + inStorage;
                     var possibleCountToEvolve = (candiesToUse / settings.CandyToEvolve;
                     amountToKeepInStorage = Math.Max(amountToKeepInStorage, possibleCountToEvolve);

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -185,23 +185,23 @@ namespace PoGo.NecroBot.Logic
                 var settings = pokemonSettings.Single(x => x.PokemonId == pokemonGroupToTransfer.Key);
                 var familyCandy = pokemonFamilies.Single(x => settings.FamilyId == x.FamilyId);
 
-                int? modFromEvolve = null;
+                var inStorage = myPokemonList.Count(data => data.PokemonId == pokemonGroupToTransfer.Key);
 
                 if (keepPokemonsThatCanEvolve &&
                     pokemonsToEvolve.Contains(pokemonGroupToTransfer.Key) &&
                     settings.CandyToEvolve > 0 &&
                     settings.EvolutionIds.Count != 0)
                 {
-                    //do not try to fix something that works, goto line 220 for explonation
-                    var possibleCountToEvolve = familyCandy.Candy_ / settings.CandyToEvolve;
+                    // It does not matter if you transfer or evolve the pokemon
+                    // You always get 1 candy back
+                    // The amount of possible evolves is the amount of candies of that family
+                    // Combined with the amount of pokemon divided by the candies needed to evolve
+                    // ( FAMILY_CANDY + POKEMON_IN_STORAGE ) / CANDY_TO_EVOLVE
+                    var candiesToUse = familyCandy.Candy_ + inStorage;
+                    var possibleCountToEvolve = (candiesToUse / settings.CandyToEvolve;
                     amountToKeepInStorage = Math.Max(amountToKeepInStorage, possibleCountToEvolve);
-
-                    //remain candy
-                    modFromEvolve = familyCandy.Candy_%settings.CandyToEvolve;
                 }
-
-                var inStorage = myPokemonList.Count(data => data.PokemonId == pokemonGroupToTransfer.Key);
-
+               
                 var weakPokemonCount = pokemonGroupToTransfer.Count();
 
                 var needToRemove = inStorage - amountToKeepInStorage;
@@ -212,16 +212,6 @@ namespace PoGo.NecroBot.Logic
 
                 if (canBeRemoved <= 0)
                     continue;
-
-                //Lets calc new canBeRemoved pokemons according to transferring some of them and use it as future candy to keepPokemonsThatCanEvolve
-                if (modFromEvolve.HasValue)
-                {
-                    // its an solution in fixed numbers of equations with two variables 
-                    // (N = X + Y, X + C >= Y * E) -> (X >= (N * E - C / 1 + E)
-                    // where N - current canBeRemoved,  X - new canBeRemoved, Y - possible to keep more, E - CandyToEvolve, C - modFromEvolve(remain candy) ) )
-                    canBeRemoved = (settings.CandyToEvolve * canBeRemoved - modFromEvolve.Value) / (1 + settings.CandyToEvolve) + 
-                                    Math.Sign((settings.CandyToEvolve * canBeRemoved - modFromEvolve.Value) % (1 + settings.CandyToEvolve));
-                }
 
                 var skipCount = weakPokemonCount - canBeRemoved;
                 


### PR DESCRIPTION
There was too much calculation going on that did not result in the correct value. Spent the whole afternoon checking it. Does not matter whether you transfer a Pokemon or evolve it, you always get 1 candy for it. So the formula is now simplified to reflect it.