### PR TITLE
Don't use red colors for anything but fatal errors!

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleLogger.cs
+++ b/PoGo.NecroBot.CLI/ConsoleLogger.cs
@@ -83,7 +83,7 @@ namespace PoGo.NecroBot.CLI
                     Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] ({LoggingStrings.Pkmn}) {message}");
                     break;
                 case LogLevel.Flee:
-                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.ForegroundColor = ConsoleColor.Yellow;
                     Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] ({LoggingStrings.Pkmn}) {message}");
                     break;
                 case LogLevel.Transfer:


### PR DESCRIPTION
Use yellow for warnings instead.