### PR TITLE
Update ConsoleEventListener.cs

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -114,11 +114,11 @@ namespace PoGo.NecroBot.CLI
 
         private static void HandleEvent(FortTargetEvent fortTargetEvent, ISession session)
         {
-            int intTimeForArrival = (int) ( fortTargetEvent.Distance / ( session.LogicSettings.WalkingSpeedInKilometerPerHour * 0.277778 ) );
+            // int intTimeForArrival = (int) ( fortTargetEvent.Distance / ( session.LogicSettings.WalkingSpeedInKilometerPerHour * 0.277778 ) );
 
             Logger.Write(
-                session.Translation.GetTranslation(TranslationString.EventFortTargeted, fortTargetEvent.Name,
-                    Math.Round(fortTargetEvent.Distance), intTimeForArrival ),
+                session.Translation.GetTranslation(TranslationString.EventFortTargeted, fortTargetEvent.Name ),
+                    // Math.Round(fortTargetEvent.Distance), intTimeForArrival ),
                 LogLevel.Info, ConsoleColor.DarkRed);
         }
 


### PR DESCRIPTION
I spent some time trying to validate the calculations being made for distance/time, but it seems impossible to account for Pokemon encounters, slow servers, transfers, evolution, etc. Therefore it makes the "Seconds until arrive at Pokestop" completely incorrect every time.

The math is correct, but every time I travel to a Pokestop the timing is at least 50%-120% greater than it declares because of factors that would be way too hard to factor in for it to be worth it. I propose we (temporarily?) remove the seconds until reaching pokestop from displaying because it only adds to the obnoxious questions, "Why API Slow?" "Why it say 10s and take 20s?" 

Once we can accurately account for all the other factors in addition to the delay between actions, it'll be appropriate to display.