### PR TITLE
Randomize Recycle v2

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -158,6 +158,8 @@ namespace PoGo.NecroBot.Logic
         int MinDelayBetweenSnipes { get; }
         double SnipingScanOffset { get; }
         bool SnipePokemonNotInPokedex { get; }
+        bool RandomizeRecycle { get; }
+        int RandomRecycleValue { get; }
         int TotalAmountOfPokeballsToKeep { get; }
         int TotalAmountOfPotionsToKeep { get; }
         int TotalAmountOfRevivesToKeep { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -388,6 +388,10 @@ namespace PoGo.NecroBot.Logic
         public int MaxPokeballsPerPokemon;
         [DefaultValue(1000)]
         public int MaxTravelDistanceInMeters;
+        [DefaultValue(false)]
+        public bool RandomizeRecycle;
+        [DefaultValue(5)]
+        public int RandomRecycleValue;
         [DefaultValue(120)]
         public int TotalAmountOfPokeballsToKeep;
         [DefaultValue(80)]
@@ -1293,6 +1297,8 @@ namespace PoGo.NecroBot.Logic
         public int MinDelayBetweenSnipes => _settings.MinDelayBetweenSnipes;
         public double SnipingScanOffset => _settings.SnipingScanOffset;
         public bool SnipePokemonNotInPokedex => _settings.SnipePokemonNotInPokedex;
+        public bool RandomizeRecycle => _settings.RandomizeRecycle;
+        public int RandomRecycleValue => _settings.RandomRecycleValue;
         public int TotalAmountOfPokeballsToKeep => _settings.TotalAmountOfPokeballsToKeep;
         public int TotalAmountOfPotionsToKeep => _settings.TotalAmountOfPotionsToKeep;
         public int TotalAmountOfRevivesToKeep => _settings.TotalAmountOfRevivesToKeep;

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -389,7 +389,7 @@ namespace PoGo.NecroBot.Logic
         [DefaultValue(1000)]
         public int MaxTravelDistanceInMeters;
         [DefaultValue(false)]
-        public bool RandomizeRecycle;
+        public bool RandomizeRecycle; //Setup for variable recycling values
         [DefaultValue(5)]
         public int RandomRecycleValue;
         [DefaultValue(120)]

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -143,7 +143,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             if (totalBallsCount > session.LogicSettings.TotalAmountOfPokeballsToKeep)
             {
                 if (RandomizeRecycle) {
-                    Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep + rnd.Next(-1*RandomRecycleValue,RandomRecycleValue);
+                    Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
                     Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep;
@@ -178,7 +178,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             if (totalPotionsCount > session.LogicSettings.TotalAmountOfPotionsToKeep)
             {
                 if (RandomizeRecycle) {
-                    Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep + rnd.Next(-1*RandomRecycleValue,RandomRecycleValue);
+                    Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
                     Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep;
@@ -214,7 +214,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             if (totalRevivesCount > session.LogicSettings.TotalAmountOfRevivesToKeep)
             {
                 if (RandomizeRecycle) {
-                    Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep + rnd.Next(-1*RandomRecycleValue,RandomRecycleValue);
+                    Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
                     Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep;
@@ -243,7 +243,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             if (totalBerryCount > session.LogicSettings.TotalAmountOfBerriesToKeep)
             {
                 if (RandomizeRecycle) {
-                    Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep + rnd.Next(-1*RandomRecycleValue,RandomRecycleValue);
+                    Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
                     Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep;

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -142,7 +142,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (totalBallsCount > session.LogicSettings.TotalAmountOfPokeballsToKeep)
             {
-                if (RandomizeRecycle) {
+                if (session.LogicSettings.RandomizeRecycle) {
                     Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
@@ -177,7 +177,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalPotionsCount = potionCount + superPotionCount + hyperPotionsCount + maxPotionCount;
             if (totalPotionsCount > session.LogicSettings.TotalAmountOfPotionsToKeep)
             {
-                if (RandomizeRecycle) {
+                if (session.LogicSettings.RandomizeRecycle) {
                     Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
@@ -213,7 +213,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalRevivesCount = reviveCount + maxReviveCount;
             if (totalRevivesCount > session.LogicSettings.TotalAmountOfRevivesToKeep)
             {
-                if (RandomizeRecycle) {
+                if (session.LogicSettings.RandomizeRecycle) {
                     Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
@@ -242,7 +242,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalBerryCount = razz + bluk + nanab + pinap + wepar;
             if (totalBerryCount > session.LogicSettings.TotalAmountOfBerriesToKeep)
             {
-                if (RandomizeRecycle) {
+                if (session.LogicSettings.RandomizeRecycle) {
                     Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -17,7 +17,7 @@ namespace PoGo.NecroBot.Logic.Tasks
     public class RecycleItemsTask
     {
         private static int Diff;
-        private static Random rnd = new Random();
+        private static Random rnd = new Random(); //Random value used for Randomizing Recycle variable
 
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
@@ -142,7 +142,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (totalBallsCount > session.LogicSettings.TotalAmountOfPokeballsToKeep)
             {
-                if (session.LogicSettings.RandomizeRecycle) {
+                if (session.LogicSettings.RandomizeRecycle) { //Check if user wants human-like recycling
                     Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
@@ -177,7 +177,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalPotionsCount = potionCount + superPotionCount + hyperPotionsCount + maxPotionCount;
             if (totalPotionsCount > session.LogicSettings.TotalAmountOfPotionsToKeep)
             {
-                if (session.LogicSettings.RandomizeRecycle) {
+                if (session.LogicSettings.RandomizeRecycle) { //Check if user wants human-like recycling
                     Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
@@ -213,7 +213,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalRevivesCount = reviveCount + maxReviveCount;
             if (totalRevivesCount > session.LogicSettings.TotalAmountOfRevivesToKeep)
             {
-                if (session.LogicSettings.RandomizeRecycle) {
+                if (session.LogicSettings.RandomizeRecycle) { //Check if user wants human-like recycling
                     Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {
@@ -242,7 +242,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalBerryCount = razz + bluk + nanab + pinap + wepar;
             if (totalBerryCount > session.LogicSettings.TotalAmountOfBerriesToKeep)
             {
-                if (session.LogicSettings.RandomizeRecycle) {
+                if (session.LogicSettings.RandomizeRecycle) { //Check if user wants human-like recycling
                     Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep + rnd.Next(-1*session.LogicSettings.RandomRecycleValue,session.LogicSettings.RandomRecycleValue);
                 }
                 else {

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -16,6 +16,7 @@ namespace PoGo.NecroBot.Logic.Tasks
     public class RecycleItemsTask
     {
         private static int Diff;
+        private static Random rnd = new Random();
 
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
@@ -140,7 +141,12 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (totalBallsCount > session.LogicSettings.TotalAmountOfPokeballsToKeep)
             {
-                Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep;
+                if (RandomizeRecycle) {
+                    Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep + rnd.Next(-1*RandomRecycleValue,RandomRecycleValue);
+                }
+                else {
+                    Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep;
+                }
                 if (Diff > 0)
                 {
                     await RecycleItems(session, cancellationToken, pokeBallsCount, ItemId.ItemPokeBall);
@@ -170,7 +176,12 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalPotionsCount = potionCount + superPotionCount + hyperPotionsCount + maxPotionCount;
             if (totalPotionsCount > session.LogicSettings.TotalAmountOfPotionsToKeep)
             {
-                Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep;
+                if (RandomizeRecycle) {
+                    Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep + rnd.Next(-1*RandomRecycleValue,RandomRecycleValue);
+                }
+                else {
+                    Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep;
+                }
                 if (Diff > 0)
                 {
                     await RecycleItems(session, cancellationToken, potionCount, ItemId.ItemPotion);
@@ -201,7 +212,12 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalRevivesCount = reviveCount + maxReviveCount;
             if (totalRevivesCount > session.LogicSettings.TotalAmountOfRevivesToKeep)
             {
-                Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep;
+                if (RandomizeRecycle) {
+                    Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep + rnd.Next(-1*RandomRecycleValue,RandomRecycleValue);
+                }
+                else {
+                    Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep;
+                }
                 if (Diff > 0)
                 {
                     await RecycleItems(session, cancellationToken, reviveCount, ItemId.ItemRevive);
@@ -225,7 +241,12 @@ namespace PoGo.NecroBot.Logic.Tasks
             int totalBerryCount = razz + bluk + nanab + pinap + wepar;
             if (totalBerryCount > session.LogicSettings.TotalAmountOfBerriesToKeep)
             {
-                Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep;
+                if (RandomizeRecycle) {
+                    Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep + rnd.Next(-1*RandomRecycleValue,RandomRecycleValue);
+                }
+                else {
+                    Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep;
+                }
                 if (Diff > 0)
                 {
                     await RecycleItems(session, cancellationToken, razz, ItemId.ItemRazzBerry);

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -8,6 +8,7 @@ using PoGo.NecroBot.Logic.Utils;
 using POGOProtos.Inventory.Item;
 using System.Threading;
 using System.Threading.Tasks;
+using System;
 
 #endregion
 


### PR DESCRIPTION
Changed the random recycle from the first version to allow for users to configure it on or off, and how random it will be.

Purpose for this is to make recycling more human-like.
Example:
Pokeballs: 73
Greabballs: 49
Ultaballs: 31
Masterballs: 11
Total pokeballs = 164
TotalAmountOfPokeballsToKeep set to 120

For a human to recycle to 120, they would need to add the quantity of each of their pokeballs up and scrap accordingly. This is highly unlikely to happen, and more often than not they would just scrap a random amount of the weakest pokeballs. 

The config will give an option to turn if on and off, and set the +/- randomized value to use. 