### PR TITLE
Pokemon trasfer readability

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -64,11 +64,11 @@ namespace PoGo.NecroBot.CLI
         {
             Logger.Write(
                 session.Translation.GetTranslation(TranslationString.EventPokemonTransferred,
-                session.Translation.GetPokemonTranslation(transferPokemonEvent.Id), 
-                transferPokemonEvent.Cp,
-                transferPokemonEvent.Perfection.ToString("0.00"), 
-                transferPokemonEvent.BestCp, 
-                transferPokemonEvent.BestPerfection.ToString("0.00"), 
+                session.Translation.GetPokemonTranslation(transferPokemonEvent.Id).PadRight(12, ' '), 
+                transferPokemonEvent.Cp.ToString().PadLeft(4, ' '),
+                transferPokemonEvent.Perfection.ToString("0.00").PadLeft(6, ' '), 
+                transferPokemonEvent.BestCp.ToString().PadLeft(4, ' '), 
+                transferPokemonEvent.BestPerfection.ToString("0.00").PadLeft(6, ' '), 
                 transferPokemonEvent.FamilyCandies),
                 LogLevel.Transfer);
         }


### PR DESCRIPTION
Improve text formatting with padding for known fields length in order to
improve readability of transfer log