### PR TITLE
Fix when console width is to small

### DIFF
--- a/PoGo.NecroBot.CLI/Resources/ProgressBar.cs
+++ b/PoGo.NecroBot.CLI/Resources/ProgressBar.cs
@@ -25,6 +25,13 @@ namespace PoGo.NecroBot.CLI.Resources
         {
             try
             {
+                // Window width has be be larger than what Console.CursorLeft is set to
+                // or System.ArgumentOutOfRangeException is thrown.
+                if (Console.WindowWidth < 50 + leftOffset)
+                {
+                    Console.WindowWidth = 51 + leftOffset;
+                }
+
                 Console.ForegroundColor = barColor;
                 Console.CursorLeft = 0 + leftOffset;
                 Console.Write("[");


### PR DESCRIPTION
If you try to set `Console.CursorLeft` to a value greater than
`Console.WindowWidth` a
`System.ArgumentOutOfRangeException` is thrown.

Set `Console.WindowWidth` to 1 + max value used to set `Console.CursorLeft`.