### PR TITLE
RandomRecycle v2

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -1,4 +1,4 @@
-﻿#region using directives
+#region using directives
 
 using POGOProtos.Enums;
 using POGOProtos.Inventory.Item;
@@ -161,6 +161,8 @@ namespace PoGo.NecroBot.Logic
         int MinDelayBetweenSnipes { get; }
         double SnipingScanOffset { get; }
         bool SnipePokemonNotInPokedex { get; }
+        bool RandomizeRecycle { get; }
+        int RandomRecycleValue { get; }
         int TotalAmountOfPokeballsToKeep { get; }
         int TotalAmountOfPotionsToKeep { get; }
         int TotalAmountOfRevivesToKeep { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -398,6 +398,10 @@ namespace PoGo.NecroBot.Logic
         public int MaxPokeballsPerPokemon;
         [DefaultValue(1000)]
         public int MaxTravelDistanceInMeters;
+        [DefaultValue(false)]
+        public bool RandomizeRecycle;
+        [DefaultValue(5)]
+        public int RandomRecycleValue;
         [DefaultValue(120)]
         public int TotalAmountOfPokeballsToKeep;
         [DefaultValue(80)]
@@ -1308,6 +1312,8 @@ namespace PoGo.NecroBot.Logic
         public int MinDelayBetweenSnipes => _settings.MinDelayBetweenSnipes;
         public double SnipingScanOffset => _settings.SnipingScanOffset;
         public bool SnipePokemonNotInPokedex => _settings.SnipePokemonNotInPokedex;
+        public bool RandomizeRecycle => _settings.RandomizeRecycle;
+        public int RandomRecycleValue => _settings.RandomRecycleValue;
         public int TotalAmountOfPokeballsToKeep => _settings.TotalAmountOfPokeballsToKeep;
         public int TotalAmountOfPotionsToKeep => _settings.TotalAmountOfPotionsToKeep;
         public int TotalAmountOfRevivesToKeep => _settings.TotalAmountOfRevivesToKeep;

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -1,4 +1,4 @@
-﻿#region using directives
+#region using directives
 
 using PoGo.NecroBot.Logic.Common;
 using PoGo.NecroBot.Logic.Event;
@@ -8,6 +8,7 @@ using PoGo.NecroBot.Logic.Utils;
 using POGOProtos.Inventory.Item;
 using System.Threading;
 using System.Threading.Tasks;
+using System;
 
 #endregion
 
@@ -16,6 +17,7 @@ namespace PoGo.NecroBot.Logic.Tasks
     public class RecycleItemsTask
     {
         private static int Diff;
+        private static Random rnd = new Random();
 
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
@@ -137,10 +139,17 @@ namespace PoGo.NecroBot.Logic.Tasks
             var masterBallsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemMasterBall);
 
             int totalBallsCount = pokeBallsCount + greatBallsCount + ultraBallsCount + masterBallsCount;
+            int random = rnd.Next(-1 * session.LogicSettings.RandomRecycleValue, session.LogicSettings.RandomRecycleValue + 1);
 
             if (totalBallsCount > session.LogicSettings.TotalAmountOfPokeballsToKeep)
             {
-                Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep;
+                if (session.LogicSettings.RandomizeRecycle)
+                {
+                    Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep + random;
+                } else {
+                    Diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokeballsToKeep;
+                }
+                
                 if (Diff > 0)
                 {
                     await RecycleItems(session, cancellationToken, pokeBallsCount, ItemId.ItemPokeBall);
@@ -166,11 +175,20 @@ namespace PoGo.NecroBot.Logic.Tasks
             var superPotionCount = await session.Inventory.GetItemAmountByType(ItemId.ItemSuperPotion);
             var hyperPotionsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemHyperPotion);
             var maxPotionCount = await session.Inventory.GetItemAmountByType(ItemId.ItemMaxPotion);
-
+            
             int totalPotionsCount = potionCount + superPotionCount + hyperPotionsCount + maxPotionCount;
+            int random = rnd.Next(-1 * session.LogicSettings.RandomRecycleValue, session.LogicSettings.RandomRecycleValue + 1);
             if (totalPotionsCount > session.LogicSettings.TotalAmountOfPotionsToKeep)
             {
-                Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep;
+                if (session.LogicSettings.RandomizeRecycle)
+                {
+                    Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep + random;
+                }
+                else
+                {
+                    Diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep;
+                }
+                
                 if (Diff > 0)
                 {
                     await RecycleItems(session, cancellationToken, potionCount, ItemId.ItemPotion);
@@ -199,9 +217,17 @@ namespace PoGo.NecroBot.Logic.Tasks
             var maxReviveCount = await session.Inventory.GetItemAmountByType(ItemId.ItemMaxRevive);
 
             int totalRevivesCount = reviveCount + maxReviveCount;
+            int random = rnd.Next(-1 * session.LogicSettings.RandomRecycleValue, session.LogicSettings.RandomRecycleValue + 1);
             if (totalRevivesCount > session.LogicSettings.TotalAmountOfRevivesToKeep)
             {
-                Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep;
+                if (session.LogicSettings.RandomizeRecycle)
+                {
+                    Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep + random;
+                }
+                else
+                {
+                    Diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep;
+                }
                 if (Diff > 0)
                 {
                     await RecycleItems(session, cancellationToken, reviveCount, ItemId.ItemRevive);
@@ -223,9 +249,18 @@ namespace PoGo.NecroBot.Logic.Tasks
             var wepar = await session.Inventory.GetItemAmountByType(ItemId.ItemWeparBerry);
 
             int totalBerryCount = razz + bluk + nanab + pinap + wepar;
+            int random = rnd.Next(-1 * session.LogicSettings.RandomRecycleValue, session.LogicSettings.RandomRecycleValue + 1);
             if (totalBerryCount > session.LogicSettings.TotalAmountOfBerriesToKeep)
             {
-                Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep;
+                if (session.LogicSettings.RandomizeRecycle)
+                {
+                    Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep + random;
+                }
+                else
+                {
+                    Diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep;
+                }
+                
                 if (Diff > 0)
                 {
                     await RecycleItems(session, cancellationToken, razz, ItemId.ItemRazzBerry);


### PR DESCRIPTION
Such a rookie with Git... this should finally check out fine. Tested code and it is all hunky dory.

_Changed the random recycle from the first version to allow for users to configure it on or off, and how random it will be.

Purpose for this is to make recycling more human-like.
Example:
Pokeballs: 73
Greabballs: 49
Ultaballs: 31
Masterballs: 11
Total pokeballs = 164
TotalAmountOfPokeballsToKeep set to 120

For a human to recycle to 120, they would need to add the quantity of each of their pokeballs up and scrap accordingly. This is highly unlikely to happen, and more often than not they would just scrap a random amount of the weakest pokeballs.

The config will give an option to turn if on and off, and set the +/- randomized value to use._