### PR TITLE
[Fix] The check if AmountofBerries is less than MaxBerriesToUse was off by 1 . 

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -91,7 +91,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     
                     AmountOfBerries++;
-                    if (AmountOfBerries < session.LogicSettings.MaxBerriesToUsePerPokemon)
+                    if (AmountOfBerries <= session.LogicSettings.MaxBerriesToUsePerPokemon)
                     {
                         await
                        UseBerry(session,


### PR DESCRIPTION
Its currently only using 2 berries per pokemon when maxBerriesToUsePerPokemon is set to 3. 

If you increment your counter before you check it you need to use a less than or equal to not just less than. 
Or you can check if its less than maxBerriesTouse +1 .


