### PR TITLE
Add back a working Pokesnipers sniping implementation

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -155,6 +155,7 @@ namespace PoGo.NecroBot.Logic
         int SnipeLocationServerPort { get; }
         bool GetSniperInfoFromPokezz { get; }
         bool GetOnlyVerifiedSniperInfoFromPokezz { get; }
+        bool GetSniperInfoFromPokeSnipers { get; }
         bool UseSnipeLocationServer { get; }
         bool UseTransferIvForSnipe { get; }
         bool SnipeIgnoreUnknownIv { get; }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -53,6 +53,10 @@
       <HintPath>$(SolutionDir)\packages\C5.2.2.5073.27396\lib\portable-net40+sl50+wp80+win\C5.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="CloudFlareUtilities, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CloudFlareUtilities.0.2.1-alpha\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\CloudFlareUtilities.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="S2Geometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\S2Geometry.1.0.1\lib\portable-net45+wp8+win8\S2Geometry.dll</HintPath>
       <Private>True</Private>

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -370,6 +370,8 @@ namespace PoGo.NecroBot.Logic
         public bool GetSniperInfoFromPokezz;
         [DefaultValue(true)]
         public bool GetOnlyVerifiedSniperInfoFromPokezz;
+        [DefaultValue(true)]
+        public bool GetSniperInfoFromPokeSnipers;
         [DefaultValue(20)]
         public int MinPokeballsToSnipe;
         [DefaultValue(0)]
@@ -1302,6 +1304,7 @@ namespace PoGo.NecroBot.Logic
         public int SnipeLocationServerPort => _settings.SnipeLocationServerPort;
         public bool GetSniperInfoFromPokezz => _settings.GetSniperInfoFromPokezz;
         public bool GetOnlyVerifiedSniperInfoFromPokezz => _settings.GetOnlyVerifiedSniperInfoFromPokezz;
+        public bool GetSniperInfoFromPokeSnipers => _settings.GetSniperInfoFromPokeSnipers;
         public bool UseSnipeLocationServer => _settings.UseSnipeLocationServer;
         public bool UseTransferIvForSnipe => _settings.UseTransferIvForSnipe;
         public bool SnipeIgnoreUnknownIv => _settings.SnipeIgnoreUnknownIv;

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -1,11 +1,13 @@
 ﻿#region using directives
 
+using CloudFlareUtilities;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -109,6 +111,15 @@ namespace PoGo.NecroBot.Logic.Tasks
 
     }
 
+    public class PokemonLocation_pokesnipers
+    {
+        public int id { get; set; }
+        public int iv { get; set; }       
+        public PokemonId name { get; set; }
+        public string until { get; set; }
+        public string coords { get; set; }
+    }
+
     public class ScanResult
     {
         public string Status { get; set; }
@@ -118,6 +129,12 @@ namespace PoGo.NecroBot.Logic.Tasks
     {
         public string Status { get; set; }
         public List<PokemonLocation_pokezz> pokemons { get; set; }
+    }
+    public class ScanResult_pokesnipers
+    {
+        public string Status { get; set; }
+        [JsonProperty("results")]
+        public List<PokemonLocation_pokesnipers> pokemons { get; set; }
     }
 
     public static class SnipePokemonTask
@@ -243,7 +260,31 @@ namespace PoGo.NecroBot.Logic.Tasks
                             }
                         }
 
-                           
+                        if (session.LogicSettings.GetSniperInfoFromPokeSnipers)
+                        {
+                            var _locationsToSnipe = GetSniperInfoFrom_pokesnipers(session, pokemonIds);
+                            if (_locationsToSnipe.Any())
+                            {
+                                _lastSnipe = DateTime.Now;
+                                foreach (var location in _locationsToSnipe)
+                                {
+                                    session.EventDispatcher.Send(new SnipeScanEvent
+                                    {
+                                        Bounds = new Location(location.Latitude, location.Longitude),
+                                        PokemonId = location.Id,
+                                        //Iv = location.IV
+                                    });
+
+                                    if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1,
+                                        session, cancellationToken))
+                                        return;
+
+                                    await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
+                                    LocsVisited.Add(new PokemonLocation(location.Latitude, location.Longitude));
+                                }
+                            }
+                        }
+                        
 
                         foreach (var location in session.LogicSettings.PokemonToSnipe.Locations)
                         {
@@ -519,6 +560,72 @@ namespace PoGo.NecroBot.Logic.Tasks
                     SnipInfo.IV = pokemon._iv;
                     if (pokemon.verified || !session.LogicSettings.GetOnlyVerifiedSniperInfoFromPokezz)
                     {
+                        SnipeLocations.Add(SnipInfo);
+                    }
+                }
+
+                var locationsToSnipe = SnipeLocations?.Where(q =>
+                (!session.LogicSettings.UseTransferIvForSnipe ||
+                 (q.IV == 0 && !session.LogicSettings.SnipeIgnoreUnknownIv) ||
+                 (q.IV >= session.Inventory.GetPokemonTransferFilter(q.Id).KeepMinIvPercentage)) &&
+                !LocsVisited.Contains(new PokemonLocation(q.Latitude, q.Longitude))
+                && !(q.ExpirationTimestamp != default(DateTime) &&
+                     q.ExpirationTimestamp > new DateTime(2016) &&
+                     // make absolutely sure that the server sent a correct datetime
+                     q.ExpirationTimestamp < DateTime.Now) &&
+                (q.Id == PokemonId.Missingno || pokemonIds.Contains(q.Id))).ToList() ??
+                                   new List<SniperInfo>();
+                return locationsToSnipe;
+            }
+            return new List<SniperInfo>();
+        }
+
+        private static List<SniperInfo> GetSniperInfoFrom_pokesnipers(ISession session, List<PokemonId> pokemonIds)
+        {
+
+            var uri = $"http://pokesnipers.com/api/v1/pokemon.json";
+
+            ScanResult_pokesnipers scanResult_pokesnipers;
+            try
+            {
+                var handler = new ClearanceHandler();
+
+                // Create a HttpClient that uses the handler.
+                var client = new HttpClient(handler);
+
+                // Use the HttpClient as usual. Any JS challenge will be solved automatically for you.
+                var fullresp = client.GetStringAsync(uri).Result.Replace(" M", "Male").Replace(" F", "Female").Replace("Farfetch'd", "Farfetchd").Replace("Mr.Maleime", "MrMime");
+
+                scanResult_pokesnipers = JsonConvert.DeserializeObject<ScanResult_pokesnipers>(fullresp);
+            }
+            catch (Exception ex)
+            {
+                // most likely System.IO.IOException
+                session.EventDispatcher.Send(new ErrorEvent { Message = ex.Message });
+                scanResult_pokesnipers = new ScanResult_pokesnipers
+                {
+                    Status = "fail",
+                    pokemons = new List<PokemonLocation_pokesnipers>()
+                };
+                return new List<SniperInfo>();
+            }
+            if (scanResult_pokesnipers.pokemons != null)
+            {
+
+                SnipeLocations.RemoveAll(x => DateTime.Now > x.TimeStampAdded.AddMinutes(15));
+
+                foreach (var pokemon in scanResult_pokesnipers.pokemons)
+                {
+                    var SnipInfo = new SniperInfo();
+                    SnipInfo.Id = pokemon.name;
+                    if (null != pokemon.coords)
+                    {
+                        string[] coordsArray = pokemon.coords.Split(',');
+                        SnipInfo.Latitude = Convert.ToDouble(coordsArray[0]);
+                        SnipInfo.Longitude = Convert.ToDouble(coordsArray[1]);
+                        SnipInfo.TimeStampAdded = DateTime.Now;
+                        SnipInfo.ExpirationTimestamp = Convert.ToDateTime(pokemon.until);
+                        SnipInfo.IV = pokemon.iv;
                         SnipeLocations.Add(SnipInfo);
                     }
                 }

--- a/PoGo.NecroBot.Logic/packages.config
+++ b/PoGo.NecroBot.Logic/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="C5" version="2.2.5073.27396" targetFramework="net452" />
+  <package id="CloudFlareUtilities" version="0.2.1-alpha" targetFramework="net452" />
   <package id="GeoCoordinate" version="1.1.0" targetFramework="net45" />
   <package id="Google.Protobuf" version="3.0.0-beta4" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />


### PR DESCRIPTION
This bypasses the cloudflare protection on Pokesnipers api.  Also introduce new config option "GetSniperInfoFromPokeSnipers": "true".  This is OR'd with the Pokezz snipers, so you can snipe from both sites at the same time, or disable one or the other as wished.