### PR TITLE
Ptc login problem optimization

### DIFF
--- a/PoGo.NecroBot.Logic/Common/ApiFailureStrategy.cs
+++ b/PoGo.NecroBot.Logic/Common/ApiFailureStrategy.cs
@@ -48,7 +48,7 @@ namespace PoGo.NecroBot.Logic.Common
         {
             try
             {
-                if (_session.Settings.AuthType != AuthType.Google || _session.Settings.AuthType != AuthType.Ptc)
+                if (_session.Settings.AuthType == AuthType.Google || _session.Settings.AuthType == AuthType.Ptc)
                 {
                     await _session.Client.Login.DoLogin();
                 }

--- a/PoGo.NecroBot.Logic/State/LoginState.cs
+++ b/PoGo.NecroBot.Logic/State/LoginState.cs
@@ -30,7 +30,7 @@ namespace PoGo.NecroBot.Logic.State
 
             try
             {
-                if (session.Settings.AuthType != AuthType.Google || session.Settings.AuthType != AuthType.Ptc)
+                if (session.Settings.AuthType == AuthType.Google || session.Settings.AuthType == AuthType.Ptc)
                 {
                     await session.Client.Login.DoLogin();
                 }
@@ -117,9 +117,9 @@ namespace PoGo.NecroBot.Logic.State
                 await Task.Delay(2000, cancellationToken);
                 Environment.Exit(0);
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                //Logger.Write(e.ToString());
+                Logger.Write(e.ToString());
                 await Task.Delay(20000, cancellationToken);
                 return this;
             }


### PR DESCRIPTION
Trying to solve #3455 
If the ptc login didn't return an ptc authtoken, the user now get's the according feedback and the client should retry after a short time.
Before there was no message, no logging and a standard retry interval of 20 seconds, because no correct exception were caught.
This looked like the application just hanged for the user.