### PR TITLE
Added command line coordinate parsing

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -74,6 +74,19 @@ namespace PoGo.NecroBot.CLI
 
                 boolNeedsSetup = true;
             }
+			
+			if (args.Length > 1) {
+				string[] crds = args[1].Split(',');
+				double lat, lng;
+				try {
+					lat = Double.Parse(crds[0]);
+					lng = Double.Parse(crds[1]);
+					settings.DefaultLatitude = lat;
+					settings.DefaultLongitude = lng;
+				}
+				catch(Exception e) {}
+			}
+			
 
             var session = new Session(new ClientSettings(settings), new LogicSettings(settings));
             


### PR DESCRIPTION
If a second argument is provided, it is interpreted as a set of latitude/longitude comma-delimited coordinates, which take precedence over config file value. In case they cannot be parsed to "double", they are silently ignored.