### PR TITLE
Wait for transfers to finish before renaming

### DIFF
--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -26,7 +26,7 @@ namespace PoGo.NecroBot.Logic.State
 
             if (session.LogicSettings.TransferDuplicatePokemon)
             {
-                TransferDuplicatePokemonTask.Execute(session, cancellationToken);
+                await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
             }
 
             if (session.LogicSettings.UseLuckyEggConstantly)


### PR DESCRIPTION
So we don't rename and then transfer the same pokemon.