### PR TITLE
Read TelegramAPIKey and if it should be used from auth.json instead of config.json

### DIFF
--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -39,6 +39,11 @@ namespace PoGo.NecroBot.Logic
         public bool UseProxyAuthentication;
         public string UseProxyUsername;
         public string UseProxyPassword;
+        //Telegram
+        [DefaultValue(false)]
+        public bool UseTelegramAPI;
+        [DefaultValue(null)]
+        public string TelegramAPIKey;
         // device data
         [DefaultValue("random")]
         public string DevicePackageName;
@@ -256,10 +261,16 @@ namespace PoGo.NecroBot.Logic
         [DefaultValue(false)]
         public bool StartupWelcomeDelay;
         //Telegram
-        [DefaultValue(false)]
-        public bool UseTelegramAPI;
-        [DefaultValue(null)]
-        public string TelegramAPIKey;
+        [JsonIgnore]
+        public bool UseTelegramAPI
+        {
+            get { return Auth.UseTelegramAPI; }
+        }
+        [JsonIgnore]
+        public string TelegramAPIKey
+        {
+            get { return Auth.TelegramAPIKey;  }
+        }
 
         //console options
         [DefaultValue(10)]


### PR DESCRIPTION
As @k3nsei said in #3611, Telegram API Key should be in auth.json, as some of us use the same config for multiple bots, but the API key should not be the same.
I didn't check too deeply, but I think, the PR should do exactly that and not much more ;-)