### PR TITLE
Fix pokezz sniping socket bug

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -530,6 +530,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             List<PokemonLocation_pokezz> pokemons = new List<PokemonLocation_pokezz>();
 
             socket.On("pokemons", (msg) => {
+                socket.Close();
                 JArray data = JArray.FromObject(msg);
                 foreach (var pokeToken in data.Children())
                 {
@@ -542,11 +543,13 @@ namespace PoGo.NecroBot.Logic.Tasks
             });
 
             socket.On(Quobject.SocketIoClientDotNet.Client.Socket.EVENT_ERROR, () => {
+                socket.Close();
                 hasError = true;
                 waitforbroadcast.Set();
             });
 
             socket.On(Quobject.SocketIoClientDotNet.Client.Socket.EVENT_CONNECT_ERROR, () => {
+                socket.Close();
                 hasError = true;
                 waitforbroadcast.Set();
             });


### PR DESCRIPTION
Occasionally, you can get an error adding new pokemon to collection when it is enumerating the list.  The socket should be closed immediately after pokemon data is received to minimize the chance of this occurring.