### PR TITLE
Fix pokezz sniping socket bug

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -276,7 +276,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                                         Bounds = new Location(location.Latitude, location.Longitude),
                                         PokemonId = location.Id,
                                         Source = "PokeSnipers.com",
-                                        //Iv = location.IV
+                                        Iv = location.IV
                                     });
 
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1,
@@ -528,6 +528,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             socket.On("pokemons", (msg) =>
             {
+                socket.Close();
                 JArray data = JArray.FromObject(msg);
                 foreach (var pokeToken in data.Children())
                 {
@@ -541,12 +542,14 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             socket.On(Quobject.SocketIoClientDotNet.Client.Socket.EVENT_ERROR, () =>
             {
+                socket.Close();
                 hasError = true;
                 waitforbroadcast.Set();
             });
 
             socket.On(Quobject.SocketIoClientDotNet.Client.Socket.EVENT_CONNECT_ERROR, () =>
             {
+                socket.Close();
                 hasError = true;
                 waitforbroadcast.Set();
             });


### PR DESCRIPTION
Fix bug with pokezz sniping where you can occasionally get an error adding new pokemon to collection when it is enumerating the list.  The socket should be closed after pokemon data is received.

Also, just to save some time and not opening another pull request for a one-line fix, I also fixed the logging for pokesnipers.com sniping to pass the IV value along.