### PR TITLE
Fixe LevelUpPokemonTask to fire even when only one pokemon to upgrade

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/LevelUpPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/LevelUpPokemonTask.cs
@@ -38,7 +38,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             {
                 if (session.LogicSettings.UseLevelUpList && PokemonToLevel!=null)
                 {
-                    for (int i = 0; i < PokemonToLevel.Count - 1; i++)
+                    for (int i = 0; i < PokemonToLevel.Count; i++)
                     {
                         if (PokemonToLevel.Contains(pokemon.PokemonId))
                         {
@@ -62,7 +62,6 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                             if (upgradedNumber >= session.LogicSettings.AmountOfTimesToUpgradeLoop)
                                 break;
-                            break;
                         }
                         else
                         {


### PR DESCRIPTION
TODO: AmountOfTimesToUpgradeLoop handling should be adjusted, too.