### PR TITLE
Add teleport option - 

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -82,6 +82,7 @@ namespace PoGo.NecroBot.Logic
         int KeepMinLvl { get; }
         bool UseKeepMinLvl { get; }
         string KeepMinOperator { get; }
+        bool Teleport { get; }
         double WalkingSpeedInKilometerPerHour { get; }
         bool FastSoftBanBypass { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }

--- a/PoGo.NecroBot.Logic/Navigation.cs
+++ b/PoGo.NecroBot.Logic/Navigation.cs
@@ -222,6 +222,16 @@ namespace PoGo.NecroBot.Logic
             return result;
         }
 
+        public async Task Teleport(GeoCoordinate targetLocation)
+        {
+            await _client.Player.UpdatePlayerLocation(
+                targetLocation.Latitude,
+                targetLocation.Longitude,
+                _client.Settings.DefaultAltitude);
+
+            UpdatePositionEvent?.Invoke(targetLocation.Latitude, targetLocation.Longitude);
+        }
+
         public event UpdatePositionDelegate UpdatePositionEvent;
     }
 }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -293,6 +293,8 @@ namespace PoGo.NecroBot.Logic
         //position
         [DefaultValue(false)]
         public bool DisableHumanWalking;
+        [DefaultValue(false)]
+        public bool Teleport;
         [DefaultValue(40.785091)]
         public double DefaultLatitude;
         [DefaultValue(-73.968285)]
@@ -1330,6 +1332,7 @@ namespace PoGo.NecroBot.Logic
         public bool RandomizeRecycle => _settings.RandomizeRecycle;
         public int RandomRecycleValue => _settings.RandomRecycleValue;
         public bool DelayBetweenRecycleActions => _settings.DelayBetweenRecycleActions;
+        public bool Teleport => _settings.Teleport;
         public int TotalAmountOfPokeballsToKeep => _settings.TotalAmountOfPokeballsToKeep;
         public int TotalAmountOfPotionsToKeep => _settings.TotalAmountOfPotionsToKeep;
         public int TotalAmountOfRevivesToKeep => _settings.TotalAmountOfRevivesToKeep;

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -79,6 +79,13 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 session.EventDispatcher.Send(new FortTargetEvent {Name = fortInfo.Name, Distance = distance});
 
+                if (session.LogicSettings.Teleport)
+                {
+                    await session.Navigation.Teleport(new GeoCoordinate(fortInfo.Latitude, fortInfo.Longitude,
+                       session.Client.Settings.DefaultAltitude));
+                }
+                else
+                {
                     await session.Navigation.Move(new GeoCoordinate(pokeStop.Latitude, pokeStop.Longitude, LocationUtils.getElevation(pokeStop.Latitude, pokeStop.Longitude)),
                     session.LogicSettings.WalkingSpeedInKilometerPerHour,
                     async () =>
@@ -89,11 +96,17 @@ namespace PoGo.NecroBot.Logic.Tasks
                         await CatchIncensePokemonsTask.Execute(session, cancellationToken);
                         return true;
                     }, cancellationToken, session.LogicSettings.DisableHumanWalking);
+                }
 
                 //Catch Lure Pokemon
                 if (pokeStop.LureInfo != null)
                 {
                     await CatchLurePokemonsTask.Execute(session, pokeStop, cancellationToken);
+                }
+
+                if (session.LogicSettings.Teleport)
+                {
+                    await CatchNearbyPokemonsTask.Execute(session, cancellationToken);
                 }
 
                 FortSearchResponse fortSearch;


### PR DESCRIPTION
Instead of using human-like walking, this option allows you to teleport directly to pokestops.  You will get more softbans using this, but it can greatly speed up the xp/hr even with softbans.

Disclaimer: By the way, I did look at code from the competing fork of this bot.  So credits should go to the other bot.  The teleport code in the other bot was a little messy, so the bare minimum code was implemented to keep the behavior of teleporting and walking as close as possible.
