### PR TITLE
Bot now restarts when updating

### DIFF
--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -292,6 +292,7 @@ namespace PoGo.NecroBot.Logic.State
                             Process.Start( Path.Combine( configDir, "config.json" ) );
                             return true;
                         case "n":
+                            Utils.ErrorHandler.ThrowFatalError( session.Translation.GetTranslation( TranslationString.FinishedTransferringConfig ), 5, LogLevel.Update, true );
                             return true;
                         default:
                             Logger.Write( session.Translation.GetTranslation( TranslationString.PromptError, "y", "n" ), LogLevel.Error );

--- a/PoGo.NecroBot.Logic/Utils/ErrorHandler.cs
+++ b/PoGo.NecroBot.Logic/Utils/ErrorHandler.cs
@@ -1,7 +1,9 @@
 ﻿using PoGo.NecroBot.Logic.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -14,7 +16,7 @@ namespace PoGo.NecroBot.Logic.Utils
         /// </summary>
         /// <param name="strMessage">Optional message to display - Leave NULL to exclude message</param>
         /// <param name="timeout">The total seconds the messag will display before shutting down</param>
-        public static void ThrowFatalError( string strMessage, int timeout, LogLevel level )
+        public static void ThrowFatalError( string strMessage, int timeout, LogLevel level, bool boolRestart = false )
         {
             if( strMessage != null)
                 Logger.Write( strMessage, level );
@@ -26,6 +28,9 @@ namespace PoGo.NecroBot.Logic.Utils
                 Console.Write( "\b" + i );
                 System.Threading.Thread.Sleep( 1000 );
             }
+
+            if( boolRestart )
+                Process.Start( Assembly.GetEntryAssembly().Location );
 
             Environment.Exit( -1 );
         }


### PR DESCRIPTION
If the bot has updated, successfully transferred a config, and the user has not chosen to open the config; the bot will restart automatically.

Solves issue #3513