### PR TITLE
[Bug Fix] Teleporting less than 100m was not catching normal and incense pokemon at new pokestop. 

### DIFF
--- a/PoGo.NecroBot.Logic/Navigation.cs
+++ b/PoGo.NecroBot.Logic/Navigation.cs
@@ -148,6 +148,8 @@ namespace PoGo.NecroBot.Logic
                         _client.Player.UpdatePlayerLocation(targetLocation.Latitude, targetLocation.Longitude,
                             LocationUtils.getElevation(targetLocation.Latitude,targetLocation.Longitude));
                 UpdatePositionEvent?.Invoke(targetLocation.Latitude, targetLocation.Longitude);
+                if (functionExecutedWhileWalking != null)
+                    await functionExecutedWhileWalking(); // look for pokemon
                 return result;
             }
         }


### PR DESCRIPTION
The call to functionExecutedWhileWalking() was missing for teleporting distances less than 100m.  
Without this call CatchNearbyPokemonsTask and CatchIncensePokemonsTask dont get executed on the pokestop. 