### PR TITLE
Bug fix - Clean up sniping logic

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -229,7 +229,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                         {
                             foreach (var location in _locationsToSnipe)
                             {
-                              
                                 if ((location.ExpirationTimestamp > DateTime.Now.AddSeconds(10)) && (!LocsVisited.Contains(new PokemonLocation(location.Latitude, location.Longitude))))
                                 {
                                     session.EventDispatcher.Send(new SnipeScanEvent
@@ -243,12 +242,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                         return;
 
-                                    if (LocsVisited.Contains(new PokemonLocation(location.Latitude, location.Longitude)))break;
                                     await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
-                                    _lastSnipe = DateTime.Now;
-                                   
-                                    LocsVisited.Add(new PokemonLocation(location.Latitude, location.Longitude));
-
                                 }
                             }
                         }
@@ -261,7 +255,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                         {
                             foreach (var location in _locationsToSnipe)
                             {
-                               
                                 if ((location.ExpirationTimestamp > DateTime.Now.AddSeconds(10)) && (!LocsVisited.Contains(new PokemonLocation(location.Latitude, location.Longitude))))
                                 {
                                     session.EventDispatcher.Send(new SnipeScanEvent
@@ -274,13 +267,8 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                         return;
-                                    if (
-                                        LocsVisited.Contains(new PokemonLocation(location.Latitude, location.Longitude)))
-                                        break;
-                                        await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
-                                    _lastSnipe = DateTime.Now;
-                                    //
-                                    LocsVisited.Add(new PokemonLocation(location.Latitude, location.Longitude));
+                                    
+                                    await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
                                 }
                             }
                         }
@@ -305,14 +293,8 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                         return;
-
-                                   
                                     
-                                    if (LocsVisited.Contains(new PokemonLocation(location.Latitude, location.Longitude)))
-                                        break;
                                     await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
-                                    _lastSnipe = DateTime.Now;
-                                    LocsVisited.Add(new PokemonLocation(location.Latitude, location.Longitude));
                                 }
                             }
                         }
@@ -320,7 +302,6 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                     if (session.LogicSettings.GetSniperInfoFromPokeWatchers)
                     {
-                        _lastSnipe = DateTime.Now;
                         var _locationsToSnipe = GetSniperInfoFrom_pokewatchers(session, pokemonIds);
                         if (_locationsToSnipe.Any())
                         {
@@ -338,12 +319,8 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                         return;
-                                    if (LocsVisited.Contains(new PokemonLocation(location.Latitude, location.Longitude)))
-                                        break;
+
                                     await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
-                                    LocsVisited.Add(new PokemonLocation(location.Latitude, location.Longitude));
-
-
                                 }
                             }
                         }
@@ -383,14 +360,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                                     {
                                         if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                             return;
-
-                                       
-                                       
-                                        if (LocsVisited.Contains(new PokemonLocation(location.Latitude, location.Longitude)))
-                                            break;
+                                        
                                         await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
-                                        _lastSnipe = DateTime.Now;
-                                        LocsVisited.Add(new PokemonLocation(location.Latitude, location.Longitude));
                                     }
                                 }
                             }
@@ -408,6 +379,9 @@ namespace PoGo.NecroBot.Logic.Tasks
         private static async Task Snipe(ISession session, IEnumerable<PokemonId> pokemonIds, double latitude,
             double longitude, CancellationToken cancellationToken)
         {
+            if (LocsVisited.Contains(new PokemonLocation(latitude, longitude)))
+                return;
+
             var CurrentLatitude = session.Client.CurrentLatitude;
             var CurrentLongitude = session.Client.CurrentLongitude;
             var catchedPokemon = false;
@@ -444,7 +418,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 if (!LocsVisited.Contains(new PokemonLocation(latitude, longitude)))
                     LocsVisited.Add(new PokemonLocation(latitude, longitude));
             }
-
+            
             foreach (var pokemon in catchablePokemon)
             {
                 EncounterResponse encounter;
@@ -520,6 +494,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     Message = session.Translation.GetTranslation(TranslationString.NoPokemonToSnipe)
                 });
             }
+
+            _lastSnipe = DateTime.Now;
 
             session.EventDispatcher.Send(new SnipeModeEvent { Active = false });
             await Task.Delay(session.LogicSettings.DelayBetweenPlayerActions, cancellationToken);

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -152,7 +152,6 @@ namespace PoGo.NecroBot.Logic.Tasks
     public static class SnipePokemonTask
     {
         public static List<PokemonLocation> LocsVisited = new List<PokemonLocation>();
-        public static List<SniperInfo> LocsVisited2 = new List<SniperInfo>();
         private static readonly List<SniperInfo> SnipeLocations = new List<SniperInfo>();
         private static DateTime _lastSnipe = DateTime.MinValue;
         


### PR DESCRIPTION
1. Remove redundant checks to locations visited (was checking this twice unnecessarily)
2. Remove double-addition and incorrect addition to locations visited (it would blacklist a location even if sniping did not occur due to full pokemon inventory for instance).
3. Cleanup last sniping time (should be set within the ```Snipe``` function).

By the way, this is a revert of most of the changes made in 329306bf469437827376204f923234f059f66be7