### PR TITLE
Fix telegram /pokedex command for missing no

### DIFF
--- a/PoGo.NecroBot.Logic/Service/TelegramService.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramService.cs
@@ -165,12 +165,15 @@ namespace PoGo.NecroBot.Logic.Service
 
                     foreach (var pokedexItem in pokemonsToCapture)
                     {
-                        answerTextmessage += session.Translation.GetTranslation(TranslationString.PokedexPokemonNeededTelegram, Convert.ToInt32(pokedexItem), session.Translation.GetPokemonTranslation(pokedexItem));
-
-                        if (answerTextmessage.Length > 3800)
+                        if (Convert.ToInt32(pokedexItem) > 0)
                         {
-                            SendMessage(message.Chat.Id, answerTextmessage);
-                            answerTextmessage = "";
+                            answerTextmessage += session.Translation.GetTranslation(TranslationString.PokedexPokemonNeededTelegram, Convert.ToInt32(pokedexItem), session.Translation.GetPokemonTranslation(pokedexItem));
+
+                            if (answerTextmessage.Length > 3800)
+                            {
+                                SendMessage(message.Chat.Id, answerTextmessage);
+                                answerTextmessage = "";
+                            }
                         }
                     }
                     SendMessage(message.Chat.Id, answerTextmessage);


### PR DESCRIPTION

## Short Description:
Fix telegram /pokedex command for extramissing no

--- Pokedex needed --- 
_#0# Name: Translation for pokemon Missingno is missing_ 
#2# Name: Ivysaur 
#3# Name: Venusaur 
#5# Name: Charmeleon 

## Fixes (provide links to github issues if you can):
