### PR TITLE
minEggKm for limited incubators (updated default value)

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -89,6 +89,7 @@ namespace PoGo.NecroBot.Logic
         bool TransferDuplicatePokemon { get; }
         bool TransferDuplicatePokemonOnCapture { get; }
         bool UseEggIncubators { get; }
+        int minEggKmForLimitedIncubators { get; }
         int UseGreatBallAboveCp { get; }
         int UseUltraBallAboveCp { get; }
         int UseMasterBallAboveCp { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -351,6 +351,8 @@ namespace PoGo.NecroBot.Logic
         //lucky, incense and berries
         [DefaultValue(true)]
         public bool UseEggIncubators;
+        [DefaultValue(10)]
+        public int minEggKmForLimitedIncubators;
         [DefaultValue(false)]
         public bool UseLuckyEggConstantly;
         [DefaultValue(30)]
@@ -1249,6 +1251,7 @@ namespace PoGo.NecroBot.Logic
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
         public bool TransferDuplicatePokemonOnCapture => _settings.TransferDuplicatePokemonOnCapture;
         public bool UseEggIncubators => _settings.UseEggIncubators;
+        public int minEggKmForLimitedIncubators => _settings.minEggKmForLimitedIncubators;
         public int UseGreatBallAboveCp => _settings.UseGreatBallAboveCp;
         public int UseUltraBallAboveCp => _settings.UseUltraBallAboveCp;
         public int UseMasterBallAboveCp => _settings.UseMasterBallAboveCp;

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -351,7 +351,7 @@ namespace PoGo.NecroBot.Logic
         //lucky, incense and berries
         [DefaultValue(true)]
         public bool UseEggIncubators;
-        [DefaultValue(10)]
+        [DefaultValue(2)]
         public int minEggKmForLimitedIncubators;
         [DefaultValue(false)]
         public bool UseLuckyEggConstantly;

--- a/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
@@ -1,4 +1,4 @@
-﻿#region using directives
+#region using directives
 
 using System;
 using System.Collections.Generic;
@@ -79,6 +79,10 @@ namespace PoGo.NecroBot.Logic.Tasks
                         : unusedEggs.LastOrDefault();
 
                     if (egg == null)
+                        continue;
+
+                    //avoid using 2/5 km eggs with limited incubator
+                    if (egg.EggKmWalkedTarget < session.LogicSettings.minEggKmForLimitedIncubators && incubator.ItemId != ItemId.ItemIncubatorBasicUnlimited)
                         continue;
 
                     var response = await session.Client.Inventory.UseItemEggIncubator(incubator.Id, egg.Id);


### PR DESCRIPTION
I've updated the minEggKm for limited incubators pull request to now by default do nothing. The user can then change the setting to 5 or 10 km to only allow these eggs in the incubator.