### PR TITLE
InnerException isn't always defined

### DIFF
--- a/PoGo.NecroBot.Logic/Common/ApiFailureStrategy.cs
+++ b/PoGo.NecroBot.Logic/Common/ApiFailureStrategy.cs
@@ -135,7 +135,7 @@ namespace PoGo.NecroBot.Logic.Common
             {
                 _session.EventDispatcher.Send(new ErrorEvent
                 {
-                    Message = ex.InnerException.ToString()
+                    Message = (ex.InnerException ?? ex).ToString()
                 });
             }
         }


### PR DESCRIPTION
## Short Description:

When Tasks are cancelled there isn't an InnerException so this code throws another unhandled exception with a NPR.