### PR TITLE
Replace SnipeWithSkiplagged by GetSniperInfoFromSkiplagged

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -159,9 +159,9 @@ namespace PoGo.NecroBot.Logic
         int SnipeLocationServerPort { get; }
         bool GetSniperInfoFromPokezz { get; }
         bool GetOnlyVerifiedSniperInfoFromPokezz { get; }
-        bool GetSniperInfoFromPokeSnipers { get; }
+        bool PokeSnipers { get; }
         bool GetSniperInfoFromPokeWatchers { get; }
-        bool SnipeWithSkiplagged { get; }
+        bool GetSniperInfoFromSkiplagged { get; }
         bool UseSnipeLocationServer { get; }
         bool UseTransferIvForSnipe { get; }
         bool SnipeIgnoreUnknownIv { get; }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -159,7 +159,7 @@ namespace PoGo.NecroBot.Logic
         int SnipeLocationServerPort { get; }
         bool GetSniperInfoFromPokezz { get; }
         bool GetOnlyVerifiedSniperInfoFromPokezz { get; }
-        bool PokeSnipers { get; }
+        bool GetSniperInfoFromPokeSnipers { get; }
         bool GetSniperInfoFromPokeWatchers { get; }
         bool GetSniperInfoFromSkiplagged { get; }
         bool UseSnipeLocationServer { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -439,7 +439,7 @@ namespace PoGo.NecroBot.Logic
         [DefaultValue(true)]
         public bool GetSniperInfoFromPokeWatchers;
         [DefaultValue(true)]
-        public bool SnipeWithSkiplagged;
+        public bool GetSniperInfoFromSkiplagged;
         [DefaultValue(20)]
         public int MinPokeballsToSnipe;
         [DefaultValue(0)]
@@ -1425,7 +1425,7 @@ namespace PoGo.NecroBot.Logic
         public bool GetOnlyVerifiedSniperInfoFromPokezz => _settings.GetOnlyVerifiedSniperInfoFromPokezz;
         public bool GetSniperInfoFromPokeSnipers => _settings.GetSniperInfoFromPokeSnipers;
         public bool GetSniperInfoFromPokeWatchers => _settings.GetSniperInfoFromPokeWatchers;
-        public bool SnipeWithSkiplagged => _settings.SnipeWithSkiplagged;
+        public bool GetSniperInfoFromSkiplagged => _settings.GetSniperInfoFromSkiplagged;
         public bool UseSnipeLocationServer => _settings.UseSnipeLocationServer;
         public bool UseTransferIvForSnipe => _settings.UseTransferIvForSnipe;
         public bool SnipeIgnoreUnknownIv => _settings.SnipeIgnoreUnknownIv;

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -324,7 +324,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         }
                     }
 
-                    if (session.LogicSettings.SnipeWithSkiplagged)
+                    if (session.LogicSettings.GetSniperInfoFromSkiplagged)
                     {
                         foreach (var location in session.LogicSettings.PokemonToSnipe.Locations)
                         {


### PR DESCRIPTION
## Short Description:
Currently, config settings for sources of sniping information are specified as follows:
  "GetSniperInfoFromPokezz": false,
  "GetSniperInfoFromPokeSnipers": true,
  "GetSniperInfoFromPokeWatchers": false,
  "SnipeWithSkiplagged": true,

This PR renames SnipeWithSkiplagged to GetSniperInfoFromSkiplagged in order to unify config setting names.

## Fixes (provide links to github issues if you can):
none