### PR TITLE
Upgrade to .NET Framework 4.6.2

### DIFF
--- a/PoGo.NecroBot.CLI/App.config
+++ b/PoGo.NecroBot.CLI/App.config
@@ -1,31 +1,31 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="PoGo.NecroBot.CLI.UserSettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
-      <section name="PoGo.NecroBot.CLI.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+      <section name="PoGo.NecroBot.CLI.UserSettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+      <section name="PoGo.NecroBot.CLI.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
     </sectionGroup>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="C5" publicKeyToken="282361b99ded7e8e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.5947.17248" newVersion="2.4.5947.17248" />
+        <assemblyIdentity name="C5" publicKeyToken="282361b99ded7e8e" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.4.5947.17248" newVersion="2.4.5947.17248"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.15.0" newVersion="1.2.15.0" />
+        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.15.0" newVersion="1.2.15.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="Pogo" connectionString="DatasetId = YOUR_DATASET_ID; CertificateFilePath = C:\Path\To\Your\Certificate\File-privatekey.p12; ServiceAccountId = your-service-account-email@developer.gserviceaccount.com; CertificatePassword = notasecret" />
+    <add name="Pogo" connectionString="DatasetId = YOUR_DATASET_ID; CertificateFilePath = C:\Path\To\Your\Certificate\File-privatekey.p12; ServiceAccountId = your-service-account-email@developer.gserviceaccount.com; CertificatePassword = notasecret"/>
   </connectionStrings>
 </configuration>

--- a/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
+++ b/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PoGo.NecroBot.CLI</RootNamespace>
     <AssemblyName>NecroBot</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -205,7 +205,9 @@
     <Compile Include="WebSocketInterface.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Config\Translations\translation.uk_UA.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/PoGo.NecroBot.ConfigUI/App.config
+++ b/PoGo.NecroBot.ConfigUI/App.config
@@ -1,17 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="C5" publicKeyToken="282361b99ded7e8e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.5947.17248" newVersion="2.4.5947.17248" />
+        <assemblyIdentity name="C5" publicKeyToken="282361b99ded7e8e" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.4.5947.17248" newVersion="2.4.5947.17248"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/PoGo.NecroBot.ConfigUI/PoGo.NecroBot.ConfigUI.csproj
+++ b/PoGo.NecroBot.ConfigUI/PoGo.NecroBot.ConfigUI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PoGo.NecroBot.ConfigUI</RootNamespace>
     <AssemblyName>NecroConfig</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -31,6 +31,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x86</PlatformTarget>

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PoGo.NecroBot.Logic</RootNamespace>
     <AssemblyName>PoGo.NecroBot.Logic</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -230,7 +230,9 @@
     <Compile Include="Utils\WebUtils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/PoGo.NecroBot.Logic/app.config
+++ b/PoGo.NecroBot.Logic/app.config
@@ -1,15 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="C5" publicKeyToken="282361b99ded7e8e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.4.5947.17248" newVersion="2.4.5947.17248" />
+        <assemblyIdentity name="C5" publicKeyToken="282361b99ded7e8e" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.4.5947.17248" newVersion="2.4.5947.17248"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>


### PR DESCRIPTION
## Short Description:

Upgrade from .NET 4.5.2 to .NET 4.6.2. .NET 4.6.2 is supported on Windows 7 and above. This would only exclude Windows Vista, as XP doesn't even support 4.5.2.

## Fixes (provide links to github issues if you can):

