### PR TITLE
Allow multiple movesets to be defined.

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -47,7 +47,7 @@ namespace PoGo.NecroBot.Logic
         }
 
         public TransferFilter(int keepMinCp, int keepMinLvl, bool useKeepMinLvl, float keepMinIvPercentage, string keepMinOperator, int keepMinDuplicatePokemon, 
-            List<PokemonMove> moves = null, string movesOperator = "or")
+            List<List<PokemonMove>> moves = null, string movesOperator = "or")
         {
             KeepMinCp = keepMinCp;
             KeepMinLvl = keepMinLvl;
@@ -55,7 +55,7 @@ namespace PoGo.NecroBot.Logic
             KeepMinIvPercentage = keepMinIvPercentage;
             KeepMinDuplicatePokemon = keepMinDuplicatePokemon;
             KeepMinOperator = keepMinOperator;
-            Moves = moves ?? new List<PokemonMove>();
+            Moves = moves ?? new List<List<PokemonMove>>();
             MovesOperator = movesOperator;
         }
 
@@ -64,7 +64,7 @@ namespace PoGo.NecroBot.Logic
         public bool UseKeepMinLvl { get; set; }
         public float KeepMinIvPercentage { get; set; }
         public int KeepMinDuplicatePokemon { get; set; }
-        public List<PokemonMove> Moves { get; set; }
+        public List<List<PokemonMove>> Moves { get; set; }
         public string KeepMinOperator { get; set; }
         public string MovesOperator { get; set; }
     }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -103,15 +103,19 @@ namespace PoGo.NecroBot.Logic
                         {
                             var pokemonTransferFilter = GetPokemonTransferFilter(p.PokemonId);
 
-                            return
-                                !pokemonTransferFilter.MovesOperator.BoolFunc(
-                                    pokemonTransferFilter.Moves.Intersect(new[] { p.Move1, p.Move2 }).Any(),
+                            bool ret = true;
+                            pokemonTransferFilter.Moves.ForEach(moveset =>
+                            {
+                                ret = !pokemonTransferFilter.MovesOperator.BoolFunc(
+                                    moveset.Intersect(new[] { p.Move1, p.Move2 }).Any(),
                                     pokemonTransferFilter.KeepMinOperator.BoolFunc(
                                         p.Cp >= pokemonTransferFilter.KeepMinCp,
                                         PokemonInfo.CalculatePokemonPerfection(p) >= pokemonTransferFilter.KeepMinIvPercentage,
                                         pokemonTransferFilter.KeepMinOperator.ReverseBoolFunc(
                                             pokemonTransferFilter.KeepMinOperator.InverseBool(pokemonTransferFilter.UseKeepMinLvl),
                                             PokemonInfo.GetLevel(p) >= pokemonTransferFilter.KeepMinLvl)));
+                            });
+                            return ret;
                         }).ToList();
             }
             catch (Exception e)

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -823,7 +823,7 @@ namespace PoGo.NecroBot.Logic
                     }
                     foreach (var filter in settings.PokemonsTransferFilter.Where(x => x.Value.Moves == null))
                     {
-                        filter.Value.Moves = new List<PokemonMove>();
+                        filter.Value.Moves = new List<List<PokemonMove>>();
                     }
                     foreach (var filter in settings.PokemonsTransferFilter.Where(x => x.Value.MovesOperator == null))
                     {


### PR DESCRIPTION
## Short Description:

Allow multiple movesets to be defined per pokemon.

```
"Moves": [
   ["QuickAttack","AirCutter"],
   ["Bash","AirCutter"]
]
```

*Note*: Might cause on update the loss of old Move settings. This is due to new data structures that are not transferable.

## Fixes (provide links to github issues if you can):
#4239
