### PR TITLE
add /port to Telegram

### DIFF
--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -386,7 +386,7 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(TranslationString.ShowPokeTemplate,
                 "\n CP: {0} | IV: {1}% | Name: {2}"),
             new KeyValuePair<TranslationString, string>(TranslationString.HelpTemplate,
-                "Commands: \n \n /top <cp/iv> <amount> - Shows you top Pokemons. \n /all <cp/iv> - Shows you all Pokemons. \n /profile - Shows you profile. \n /loc - Shows you location. \n /items - Shows your items. \n /status - Shows you the Status of the Bot. \n /pokedex - Shows you Pokedex "),
+                "Commands: \n \n /top <cp/iv> <amount> - Shows you top Pokemons. \n /all <cp/iv> - Shows you all Pokemons. \n /profile - Shows you profile. \n /loc - Shows you location. \n /items - Shows your items. \n /status - Shows you the Status of the Bot. \n /pokedex - Shows your Pokedex. \n /restart - restarts the bot. \n /port <coords> - teleports you to the provided coordinates."),
             new KeyValuePair<TranslationString, string>(TranslationString.StatsXpTemplateString,
                 "{0} (Advance in {1}h {2}m | {3:n0}/{4:n0} XP)"),
             new KeyValuePair<TranslationString, string>(TranslationString.RequireInputText,

--- a/PoGo.NecroBot.Logic/Service/TelegramService.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Common;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.PoGoUtils;

--- a/PoGo.NecroBot.Logic/Service/TelegramService.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramService.cs
@@ -256,9 +256,27 @@ namespace PoGo.NecroBot.Logic.Service
                     SendMessage(message.Chat.Id, Console.Title);
                     break;
                 case "/restart":
-                    Process.Start(Assembly.GetEntryAssembly().Location);
                     SendMessage(message.Chat.Id, "Restarted Bot. Closing old Instance... BYE!");
+                    await Task.Delay(1000); // Wait 1 second to send the response through Telegram
+                    Process.Start(Assembly.GetEntryAssembly().Location);
                     Environment.Exit(-1);
+                    break;
+                case "/port":
+                    if(messagetext.Length < 2) {
+                        SendMessage(message.Chat.Id, "/port needs an target coordinates as argument!");
+                    } else {
+                        SendMessage(message.Chat.Id, "Porting to "+ messagetext[1] + " by restarting the bot!");
+                        ProcessStartInfo pi = new ProcessStartInfo(Assembly.GetEntryAssembly().Location);
+                        String[] args = Environment.GetCommandLineArgs();
+                        if(args.Length > 1) { // we already had some arguments... 
+                                              // 2nd one is coordinates and can therefore be omitted
+                            pi.Arguments = args[1] + " " + messagetext[1];
+                        } else {
+                            pi.Arguments = ". " + messagetext[1];
+                        }
+                        Process.Start(pi);
+                        Environment.Exit(-1);
+                    }
                     break;
                 default:
                     answerTextmessage += session.Translation.GetTranslation(TranslationString.HelpTemplate);


### PR DESCRIPTION
## Short Description:
adding "/port <coords>" parameter to Telegram bot, which restarts the bot and ports to target coordinates.