### PR TITLE
Fixed transferring ALL pokemons if no moves in config

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -103,18 +103,29 @@ namespace PoGo.NecroBot.Logic
                         {
                             var pokemonTransferFilter = GetPokemonTransferFilter(p.PokemonId);
 
-                            bool ret = true;
-                            pokemonTransferFilter.Moves.ForEach(moveset =>
+                            bool ret = false; //should start with false in case something goes horribly wrong....
+                            if (pokemonTransferFilter.Moves.Count > 0) 
                             {
-                                ret = !pokemonTransferFilter.MovesOperator.BoolFunc(
-                                    moveset.Intersect(new[] { p.Move1, p.Move2 }).Any(),
-                                    pokemonTransferFilter.KeepMinOperator.BoolFunc(
-                                        p.Cp >= pokemonTransferFilter.KeepMinCp,
-                                        PokemonInfo.CalculatePokemonPerfection(p) >= pokemonTransferFilter.KeepMinIvPercentage,
-                                        pokemonTransferFilter.KeepMinOperator.ReverseBoolFunc(
-                                            pokemonTransferFilter.KeepMinOperator.InverseBool(pokemonTransferFilter.UseKeepMinLvl),
-                                            PokemonInfo.GetLevel(p) >= pokemonTransferFilter.KeepMinLvl)));
-                            });
+                                pokemonTransferFilter.Moves.ForEach(moveset =>
+                                {
+                                    ret = !pokemonTransferFilter.MovesOperator.BoolFunc(
+                                        moveset.Intersect(new[] { p.Move1, p.Move2 }).Any(),
+                                        pokemonTransferFilter.KeepMinOperator.BoolFunc(
+                                            p.Cp >= pokemonTransferFilter.KeepMinCp,
+                                            PokemonInfo.CalculatePokemonPerfection(p) >= pokemonTransferFilter.KeepMinIvPercentage,
+                                            pokemonTransferFilter.KeepMinOperator.ReverseBoolFunc(
+                                                pokemonTransferFilter.KeepMinOperator.InverseBool(pokemonTransferFilter.UseKeepMinLvl),
+                                                PokemonInfo.GetLevel(p) >= pokemonTransferFilter.KeepMinLvl)));
+                                });
+                            } else
+                            {
+                                ret = !pokemonTransferFilter.KeepMinOperator.BoolFunc(
+                                    p.Cp >= pokemonTransferFilter.KeepMinCp,
+                                    PokemonInfo.CalculatePokemonPerfection(p) >= pokemonTransferFilter.KeepMinIvPercentage,
+                                    pokemonTransferFilter.KeepMinOperator.ReverseBoolFunc(
+                                        pokemonTransferFilter.KeepMinOperator.InverseBool(pokemonTransferFilter.UseKeepMinLvl),
+                                        PokemonInfo.GetLevel(p) >= pokemonTransferFilter.KeepMinLvl));
+                            }
                             return ret;
                         }).ToList();
             }


### PR DESCRIPTION
the ForEach didn't got triggered at all if no Moves are defined.
I fixed that and set the default return value to false in case something
else goes horribly wrong at least the pokemon shouldn't be transfered.