### PR TITLE
Return unique pokemon id with evolve/catch notification

### DIFF
--- a/PoGo.NecroBot.Logic/Event/PokemonCaptureEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/PokemonCaptureEvent.cs
@@ -18,7 +18,7 @@ namespace PoGo.NecroBot.Logic.Event
         public int Exp;
         public int FamilyCandies;
         public PokemonId Id;
-        public uint uniqueId;
+        public ulong uniqueId;
         public double Level;
         public int MaxCp;
         public double Perfection;

--- a/PoGo.NecroBot.Logic/Event/PokemonCaptureEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/PokemonCaptureEvent.cs
@@ -18,7 +18,7 @@ namespace PoGo.NecroBot.Logic.Event
         public int Exp;
         public int FamilyCandies;
         public PokemonId Id;
-        public ulong uniqueId;
+        public ulong UniqueId;
         public double Level;
         public int MaxCp;
         public double Perfection;

--- a/PoGo.NecroBot.Logic/Event/PokemonCaptureEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/PokemonCaptureEvent.cs
@@ -18,6 +18,7 @@ namespace PoGo.NecroBot.Logic.Event
         public int Exp;
         public int FamilyCandies;
         public PokemonId Id;
+        public uint uniqueId;
         public double Level;
         public int MaxCp;
         public double Perfection;

--- a/PoGo.NecroBot.Logic/Event/PokemonEvolveEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/PokemonEvolveEvent.cs
@@ -11,7 +11,7 @@ namespace PoGo.NecroBot.Logic.Event
     {
         public int Exp;
         public PokemonId Id;
-        public uint UniqueId;
+        public ulong UniqueId;
         public EvolvePokemonResponse.Types.Result Result;
     }
 }

--- a/PoGo.NecroBot.Logic/Event/PokemonEvolveEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/PokemonEvolveEvent.cs
@@ -11,6 +11,7 @@ namespace PoGo.NecroBot.Logic.Event
     {
         public int Exp;
         public PokemonId Id;
+        public uint UniqueId;
         public EvolvePokemonResponse.Types.Result Result;
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -197,6 +197,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                     evt.Exp = totalExp;
                     evt.Stardust = profile.PlayerData.Currencies.ToArray()[1].Amount;
+                    evt.UniqueId = caughtPokemonResponse.CapturedPokemonId;
 
                     var pokemonSettings = await session.Inventory.GetPokemonSettings();
                     var pokemonFamilies = await session.Inventory.GetPokemonFamilies();

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -118,6 +118,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     Id = pokemon.PokemonId,
                     Exp = evolveResponse.ExperienceAwarded,
+                    UniqueId = pokemon.Id,
                     Result = evolveResponse.Result
                 });
                 if (!pokemonToEvolve.Last().Equals(pokemon))

--- a/PoGo.NecroBot.Logic/Tasks/EvolveSpecificPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolveSpecificPokemonTask.cs
@@ -26,6 +26,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             {
                 Id = pokemon.PokemonId,
                 Exp = evolveResponse.ExperienceAwarded,
+                UniqueId = pokemon.Id,
                 Result = evolveResponse.Result
             });
             DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);


### PR DESCRIPTION
## Short Description:
Extended the PokemonEvolveEvent and PokemonCaptureEvent classes with a ulong field for storing the unique pokemon ID to be sent out through the websocket notifications.
Enhanced the EvolvePokemonTask, EvolveSpecificPokemonTask and the CatchPokemonTask so they fill out these new fields when the event objects are created.

## Fixes (provide links to github issues if you can):
https://github.com/NECROBOTIO/NecroBot/issues/4014