### PR TITLE
Bug fix - Sniping from pokezz fixed after pokezz implementation change

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -554,7 +554,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             var socket = IO.Socket("http://pokezz.com", options);
 
-            var hasError = false;
+            var hasError = true;
 
             ManualResetEventSlim waitforbroadcast = new ManualResetEventSlim(false);
 
@@ -562,6 +562,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             socket.On("pokemons", (msg) =>
             {
+                hasError = false;
                 socket.Close();
                 JArray data = JArray.FromObject(msg);
 
@@ -577,18 +578,17 @@ namespace PoGo.NecroBot.Logic.Tasks
             socket.On(Quobject.SocketIoClientDotNet.Client.Socket.EVENT_ERROR, () =>
             {
                 socket.Close();
-                hasError = true;
                 waitforbroadcast.Set();
             });
 
             socket.On(Quobject.SocketIoClientDotNet.Client.Socket.EVENT_CONNECT_ERROR, () =>
             {
                 socket.Close();
-                hasError = true;
                 waitforbroadcast.Set();
             });
 
-            waitforbroadcast.Wait();
+            waitforbroadcast.Wait(5000); // Wait a maximum of 5 seconds for Pokezz to respond.
+            socket.Close();
             if (!hasError)
             {
                 foreach (var pokemon in pokemons)


### PR DESCRIPTION
## Short Description:
Fixes pokezz sniping when pokezz website is down.   Currently, if pokezz is not responding, then the bot will just do nothing when it starts to snipe.  It just waits indefinitely.

Now I've added a 5 second timeout, so that bot continues along if pokezz is not responding within 5 seconds.