### PR TITLE
Add missing await calls

### DIFF
--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -22,7 +22,7 @@ namespace PoGo.NecroBot.Logic.State
 
             if (session.LogicSettings.UseEggIncubators)
             {
-                UseIncubatorsTask.Execute(session, cancellationToken);
+                await UseIncubatorsTask.Execute(session, cancellationToken);
             }
 
             if (session.LogicSettings.TransferDuplicatePokemon)
@@ -32,24 +32,24 @@ namespace PoGo.NecroBot.Logic.State
 
             if (session.LogicSettings.UseLuckyEggConstantly)
             {
-                UseLuckyEggConstantlyTask.Execute(session, cancellationToken);
+                await UseLuckyEggConstantlyTask.Execute(session, cancellationToken);
             }
 
             if (session.LogicSettings.UseIncenseConstantly)
             {
-                UseIncenseConstantlyTask.Execute(session, cancellationToken);
+                await UseIncenseConstantlyTask.Execute(session, cancellationToken);
             }
 
             await GetPokeDexCount.Execute(session, cancellationToken);
 
             if (session.LogicSettings.RenamePokemon)
             {
-                RenamePokemonTask.Execute(session, cancellationToken);
+                await RenamePokemonTask.Execute(session, cancellationToken);
             }
 
             if (session.LogicSettings.AutoFavoritePokemon)
             {
-                FavoritePokemonTask.Execute(session, cancellationToken);
+                await FavoritePokemonTask.Execute(session, cancellationToken);
             }
 
             await RecycleItemsTask.Execute(session, cancellationToken);


### PR DESCRIPTION
Fixes up the compiler warnings:
```
Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
```