### PR TITLE
More changes to compile under .NET 4.5.2.

### DIFF
--- a/PoGo.NecroBot.CLI/App.config
+++ b/PoGo.NecroBot.CLI/App.config
@@ -7,7 +7,7 @@
     </sectionGroup>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/PoGo.NecroBot.CLI/packages.config
+++ b/PoGo.NecroBot.CLI/packages.config
@@ -1,57 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="C5" version="2.4.5947.17249" targetFramework="net462" />
+  <package id="C5" version="2.4.5947.17249" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.0.0-beta4" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
-  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net462" />
-  <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net462" />
-  <package id="NETStandard.Library" version="1.6.0" targetFramework="net462" />
+  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net452" />
+  <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="S2Geometry" version="1.0.3" targetFramework="net462" />
+  <package id="S2Geometry" version="1.0.3" targetFramework="net452" />
   <package id="SuperSocket" version="1.6.6.1" targetFramework="net45" />
   <package id="SuperSocket.Engine" version="1.6.6.1" targetFramework="net45" />
   <package id="SuperSocket.WebSocket" version="1.6.6.1" targetFramework="net45" />
-  <package id="System.AppContext" version="4.1.0" targetFramework="net462" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net462" />
-  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
-  <package id="System.Console" version="4.0.0" targetFramework="net462" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.0.0" targetFramework="net462" />
-  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net462" />
-  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net462" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net462" />
-  <package id="System.Globalization.Calendars" version="4.0.1" targetFramework="net462" />
-  <package id="System.IO" version="4.1.0" targetFramework="net462" />
-  <package id="System.IO.Compression" version="4.1.0" targetFramework="net462" />
-  <package id="System.IO.Compression.ZipFile" version="4.0.1" targetFramework="net462" />
-  <package id="System.IO.FileSystem" version="4.0.1" targetFramework="net462" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net462" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net462" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net462" />
-  <package id="System.Net.Http" version="4.1.0" targetFramework="net462" />
-  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net462" />
-  <package id="System.Net.Sockets" version="4.1.0" targetFramework="net462" />
-  <package id="System.ObjectModel" version="4.0.12" targetFramework="net462" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="net462" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net462" />
-  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net462" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net462" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net462" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net462" />
-  <package id="System.Runtime.Handles" version="4.0.1" targetFramework="net462" />
-  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net462" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net462" />
-  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.2.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net462" />
-  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net462" />
-  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net462" />
-  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net462" />
-  <package id="System.Threading" version="4.0.11" targetFramework="net462" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net462" />
-  <package id="System.Threading.Timer" version="4.0.1" targetFramework="net462" />
-  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net462" />
-  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net462" />
+  <package id="System.AppContext" version="4.1.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
+  <package id="System.Console" version="4.0.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.0.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
+  <package id="System.Globalization.Calendars" version="4.0.1" targetFramework="net452" />
+  <package id="System.IO" version="4.1.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.1.0" targetFramework="net452" />
+  <package id="System.IO.Compression.ZipFile" version="4.0.1" targetFramework="net452" />
+  <package id="System.IO.FileSystem" version="4.0.1" targetFramework="net452" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net452" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.1.0" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net452" />
+  <package id="System.Net.Sockets" version="4.1.0" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net452" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.Handles" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net452" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.2.0" targetFramework="net452" />
+  <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net452" />
+  <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net452" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.0.1" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Fixes to get the project compiling again under .NET 4.5.2.  
1. Change App.config supported runtime to 4.5.2
2. Change packages to 4.5.2
3. Revert FeroxRev back to revision that compiled targetting 4.5.2.