### PR TITLE
[Bug Fix] TransferPokemonTask's do not RefreshCachedInventory before deciding what to transfer

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -87,6 +87,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     }
                     await evolve(session, pokemonToEvolve);
                 }
+                await session.Inventory.RefreshCachedInventory();
             }
         }
 

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -177,9 +177,6 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                     await RecycleItemsTask.Execute(session, cancellationToken);
 
-                    if (fortSearch.ItemsAwarded.Count > 0)
-                        await session.Inventory.RefreshCachedInventory();
-
                     if (session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
                         session.LogicSettings.EvolveAllPokemonAboveIv ||
                         session.LogicSettings.UseLuckyEggsWhileEvolving ||

--- a/PoGo.NecroBot.Logic/Tasks/LevelUpPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/LevelUpPokemonTask.cs
@@ -20,8 +20,10 @@ namespace PoGo.NecroBot.Logic.Tasks
 
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
-           
-           
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await session.Inventory.RefreshCachedInventory();
+
             if (session.Inventory.GetStarDust() <= session.LogicSettings.GetMinStarDustForLevelUp)
                 return;
             upgradablePokemon = await session.Inventory.GetPokemonToUpgrade();
@@ -30,8 +32,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 var fave = upgradablePokemon.Where(i => i.Favorite == 1);
                 upgradablePokemon = fave;
             }
-           
-           
+                      
             if (upgradablePokemon.Count() == 0)
                 return;
 
@@ -78,7 +79,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                             break;
                         }
                     }
-
                 }
                 else
                 {
@@ -100,8 +100,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if (upgradedNumber >= session.LogicSettings.AmountOfTimesToUpgradeLoop)
                         break;
                 }
-               
-                
             }
         }
     }

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -23,6 +23,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            await session.Inventory.RefreshCachedInventory();
             var currentTotalItems = await session.Inventory.GetTotalItemCount();
             if ((session.Profile.PlayerData.MaxItemStorage * session.LogicSettings.RecycleInventoryAtUsagePercentage / 100.0f) > currentTotalItems)
                 return;
@@ -106,7 +107,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                 if (session.LogicSettings.DelayBetweenRecycleActions)
                     DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
             }
-
             await session.Inventory.RefreshCachedInventory();
         }
 

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -19,6 +19,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            await session.Inventory.RefreshCachedInventory();
             var pokemons = await session.Inventory.GetPokemons();
 
             foreach (var pokemon in pokemons)

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -18,6 +18,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            await session.Inventory.RefreshCachedInventory();
             var duplicatePokemons =
                 await
                     session.Inventory.GetDuplicatePokemonToTransfer(

--- a/PoGo.NecroBot.Logic/Tasks/TransferWeakPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferWeakPokemonTask.cs
@@ -20,6 +20,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            await session.Inventory.RefreshCachedInventory();
             var pokemons = await session.Inventory.GetPokemons();
             var pokemonDatas = pokemons as IList<PokemonData> ?? pokemons.ToList();
             var pokemonsFiltered =


### PR DESCRIPTION
## Short Description:
Currently TransferPokemons task's do not refresh the cached inventory before looking for pokemon to transfer.  
When EvolvePokemonTask finishes evolving it does not update the cache. 
This can cause TransferPokemon to attempt to transfer pokemon that do not exist anymore or not transfer newly evolved duplicate pokemon. 

All tasks to change pokemon and inventory should refresh cache before and after (or maybe just after?) their operations.

TransferPokemons already have Inventory.DeletePokemonFromInvById that updates the cache after a transfer but the other tasks do not have corresponding methods.

Then we dont have to RefreshCachedInventory in FarmPokemonTask (which is currently incorrectly checking whether or not to refresh, fortsearch is only the last fort not the previous 6-12). 