### PR TITLE
Adding Version Control to JSONs and adding User Note Field to Config.JSON

### DIFF
--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -288,7 +288,7 @@ namespace PoGo.NecroBot.Logic
         [JsonIgnore]
         public bool isGui;
 
-        [DevaultValue("Put your notes here. User notes will be preserved upon updates")]
+        [DefaultValue("Put your notes here. User notes will be preserved upon updates")]
         public string ThisConfigUserNote;
         [DefaultValue("en")]
         public string TranslationLanguageCode;

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -70,6 +70,8 @@ namespace PoGo.NecroBot.Logic
         public string FirmwareType;
         [DefaultValue("htc/pmewl_00531/htc_pmewl:6.0.1/MMB29M/770927.1:user/release-keys")]
         public string FirmwareFingerprint;
+        [DefaultValue("0.0.0")]
+        public string AuthVersion;
 
         public AuthSettings()
         {
@@ -153,6 +155,7 @@ namespace PoGo.NecroBot.Logic
 
         public void Save(string fullPath)
         {
+            AuthVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
             var jsonSerializeSettings = new JsonSerializerSettings
             {
                 DefaultValueHandling = DefaultValueHandling.Include,
@@ -292,6 +295,9 @@ namespace PoGo.NecroBot.Logic
         public bool AutoUpdate;
         [DefaultValue(true)]
         public bool TransferConfigAndAuthOnUpdate;
+        //Version Control
+        [DefaultValue("0.0.0")]
+        public string ConfigVersion;
         //websockets
         [DefaultValue(false)]
         public bool UseWebsocket;
@@ -1081,6 +1087,7 @@ namespace PoGo.NecroBot.Logic
 
         public void Save(string fullPath)
         {
+            ConfigVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
             var jsonSerializeSettings = new JsonSerializerSettings
             {
                 DefaultValueHandling = DefaultValueHandling.Include,

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -288,6 +288,8 @@ namespace PoGo.NecroBot.Logic
         [JsonIgnore]
         public bool isGui;
 
+        [DevaultValue("Put your notes here. User notes will be preserved upon updates")]
+        public string ThisConfigUserNote;
         [DefaultValue("en")]
         public string TranslationLanguageCode;
         //autoupdate


### PR DESCRIPTION
_1. If you are adding configuration settings, please be sure to document their usage in your description so they can be added to the wiki._


Version Control can help in situations like changing "fraction to percentage" or "boolean to milisecond".
As to the wiki: AuthVersion and ConfigVersion parameter is system generated and user is advised not to tamper to get the most benefit of it especially on version upgrades.


"ThisConfigUserNote" in Config.JSON provide a means for user to put notes that is not deleted by the bot. Typicaly user have several configs like NewYork.Config, Tokyo.Config, Sniping.Config etc. It will help them to have a means to make notes.
For the wiki: 
"ThisConfigUserNote is intended for user to make remark on their config. User may write a short description for their own remainder of what config it is, especially if you maintain more than one config. The bot will not alter or delete your note. You may use any standard keyboard character except the quote mark " which is used as end of note by automatic JSONreader. Keep it short, in future version maybe dev team will make intensive use of JSON file and a long elaborate note may affect your bot performance. Don't forget to make a copy of your config in separate directory as the bot will delete old JSONs found in your CONFIG directory on version upgrade.


_2. Make sure your code is clean and well-formed. Use comments if necessary to explain why you did something._
It is. Hopefully.

_3. Make sure your changes are only for a specific purpose. Do not mix several changes into one pull request._
It is specific on settings.cs, OK!

_4. If the code is based off another individuals work, be sure to credit them appropriately._
No credits.
