### PR TITLE
Bahasa Indonesia: fix and update translations.

### DIFF
--- a/PoGo.NecroBot.CLI/Config/Translations/translation.id.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.id.json
@@ -26,7 +26,7 @@
     },
     {
       "Key": "farmPokestopsOutsideRadius",
-      "Value": "Anda berada diluar radius yang sudah Anda tentukan! Kembali ke posisi awal (sekitar {0} meter) dalam 5 detik. Apakah berkas LastPos.ini Anda benar?"
+      "Value": "Kamu berada diluar radius yang sudah kamu tentukan! Kembali ke posisi awal (sekitar {0} meter) dalam 5 detik. Apakah berkas LastPos.ini kamu benar?"
     },
     {
       "Key": "farmPokestopsNoUsableFound",
@@ -150,23 +150,23 @@
     },
     {
       "Key": "welcomeWarning",
-      "Value": "Pastikan koordinat Anda telah benar. Tutup program dan konfigurasi ulang jika belum! X (lintang): {0} Y (bujur): {1}"
+      "Value": "Pastikan koordinat kamu telah benar. Tutup program dan atur ulang jika belum! X (lintang): {0} Y (bujur): {1}"
     },
     {
       "Key": "incubatorPuttingEgg",
-      "Value": "Memasukkan telur ke dalam inkubator: {0:0.00} km tersisa"
+      "Value": "Memasukkan telur ke dalam inkubator: {0:0.00} KM tersisa"
     },
     {
       "Key": "incubatorStatusUpdate",
-      "Value": "Status terbaru inkubator: {0:0.00} km tersisa"
+      "Value": "Status terbaru inkubator: {0:0.00} KM tersisa"
     },
     {
       "Key": "incubatorEggHatched",
-      "Value": "Selamat !!! Telur telah menetas:  {0} | Lvl: {1} CP: ({2}/{3}) IV: {4}%"
+      "Value": "Telur telah menetas:  {0} | Lvl: {1} CP: ({2}/{3}) IV: {4}%"
     },
     {
       "Key": "logEntryError",
-      "Value": "Error"
+      "Value": "ERROR"
     },
     {
       "Key": "logEntryAttention",
@@ -270,7 +270,7 @@
     },
     {
       "Key": "gotUpToDateVersion",
-      "Value": "Info! Silahkan perbarui ke versi terbaru {0}"
+      "Value": "Sempurna! Kamu punya versi terbaru {0}"
     },
     {
       "Key": "autoUpdaterDisabled",
@@ -294,7 +294,7 @@
     },
     {
       "Key": "updateFinished",
-      "Value": "Pembaruan telah selesai, Anda dapat menutup jendela ini sekarang."
+      "Value": "Pembaruan telah selesai, kamu dapat menutup jendela ini sekarang."
     },
     {
       "Key": "lookingForIncensePokemon",
@@ -314,7 +314,7 @@
     },
     {
       "Key": "zeroPokeballInv",
-      "Value": "Anda tidak memiliki PokeBall di inventaris, tidak dapat menangkap Pokemon lagi!"
+      "Value": "Kamu tidak memiliki PokeBall di inventaris, tidak dapat menangkap Pokemon lagi!"
     },
     {
       "Key": "currentPokeballInv",
@@ -334,11 +334,11 @@
     },
     {
       "Key": "maxItemsCombinedOverMaxItemStorage",
-      "Value": "[Konfigurasi Salah] Total barang maksimum Anda (ball+potion+revive={0}) melebihi kapasitas tas Anda ({1})"
+      "Value": "[Konfigurasi Salah] Total barang maksimum kamu (ball+potion+revive={0}) melebihi kapasitas tasmu ({1})"
     },
     {
       "Key": "recyclingQuietly",
-	  "Value": "Daur ulang dengan santai..."
+	  "Value": "Mendaur ulang secara senyap..."
     },
     {
       "Key": "invFullTransferring",
@@ -362,7 +362,7 @@
     },
     {
       "Key": "desiredDestTooFar",
-      "Value": "Tujuan yang Anda inginkan {0}, {1} terlalu jauh dari posisi Anda saat ini {2}, {3}"
+      "Value": "Tujuan yang kamu inginkan {0}, {1} terlalu jauh dari posisi kamu saat ini {2}, {3}"
     },
     {
       "Key": "pokemonRename",
@@ -438,11 +438,11 @@
     },
     {
       "Key": "requireInputText",
-      "Value": "Program akan berlanjut setelah Anda menekan tombol..."
+      "Value": "Program akan berlanjut setelah kamu menekan tombol..."
     },
     {
       "Key": "googleTwoFactorAuth",
-      "Value": "Karena Anda menggunakan keamanan ganda Google, Anda perlu memasukkan kata kunci khusus aplikasi di auth.json"
+      "Value": "Karena kamu menggunakan keamanan ganda Google, kamu perlu memasukkan kata kunci khusus aplikasi di auth.json"
     },
     {
       "Key": "googleTwoFactorAuthExplanation",
@@ -450,7 +450,7 @@
     },
     {
       "Key": "googleError",
-      "Value": "Pastikan Anda memasukkan email dan password yang benar."
+      "Value": "Pastikan kamu memasukkan email dan password yang benar."
     },
     {
       "Key": "googleOffline",
@@ -458,11 +458,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "Anda harus mengisi GoogleUsername dan GooglePassword di auth.json!"
+      "Value": "Kamu harus mengisi GoogleUsername dan GooglePassword di auth.json!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "Anda harus mengisi PtcUsername dan PtcPassword di auth.json!"
+      "Value": "Kamu harus mengisi PtcUsername dan PtcPassword di auth.json!"
     },
     {
       "Key": "snipeScan",
@@ -494,7 +494,7 @@
     },
     {
       "Key": "ipBannedError",
-      "Value": "Koneksi ditolak. Alamat IP Anda mungkin sudah diblokir oleh Niantic. Keluar..."
+      "Value": "Koneksi ditolak. Alamat IP-mu mungkin sudah diblokir oleh Niantic. Keluar..."
     },
     {
       "Key": "noEggsAvailable",
@@ -546,11 +546,11 @@
     },
 	{
       "Key": "firstStartPrompt",
-      "Value": "Ini adalah pertama kalinya Anda menjalankan aplikasi, apakah Anda ingin memulai pengaturan? {0}/{1}"
+      "Value": "Ini adalah pertama kalinya kamu menjalankan aplikasi, apakah kamu ingin memulai pengaturan? {0}/{1}"
     },
 	{
       "Key": "firstStartLanguagePrompt",
-      "Value": "Apakah Anda ingin mengganti bahasa bawaan? {0}/{1}"
+      "Value": "Apakah kamu ingin mengganti bahasa bawaan? {0}/{1}"
     },
 	{
       "Key": "firstStartLanguageCodePrompt",
@@ -606,7 +606,7 @@
     },
 	{
       "Key": "firstStartDefaultLocationPrompt",
-      "Value": "Apakah Anda ingin mengatur lokasi bawaan yang baru? {0}/{1}"
+      "Value": "Apakah kamu ingin mengatur lokasi bawaan yang baru? {0}/{1}"
     },
 	{
       "Key": "firstStartDefaultLocationSet",
@@ -646,31 +646,51 @@
     },
     {
       "Key": "PokedexCatchedTelegram",
-      "Value":  "--- Tertangkap di Pokedex  --- \n"  
+      "Value":  "--- Tertangkap di Pokedex  --- \n"
     },
     {
       "Key": "PokedexPokemonCatchedTelegram",
-      "Value":  "#{0} Nama: {1} | Tertangkap: {2} | Ditemukan: {3} \n"  
+      "Value":  "#{0} Nama: {1} | Tertangkap: {2} | Ditemukan: {3} \n"
     },
     {
       "Key": "PokedexNeededTelegram",
-      "Value":  "--- Dibutuhkan di Pokedex --- \n"  
+      "Value":  "--- Dibutuhkan di Pokedex --- \n"
     },
     {
       "Key": "PokedexPokemonNeededTelegram",
-      "Value":  "#{0} Nama: {1} \n"  
+      "Value":  "#{0} Nama: {1} \n"
     },
     {
       "Key": "loggedInTelegram",
-      "Value":  "Kamu berhasil login. Sesi ini hanya valid untuk 5 menit saja."  
+      "Value":  "Kamu berhasil login. Sesi ini hanya valid untuk 5 menit saja."
     },
     {
       "Key": "loginFailedTelegram",
-      "Value":  "Password atau perintah salah! Gunakan /login <PASSWORD>"  
+      "Value":  "Password atau perintah salah! Gunakan /login <PASSWORD>"
     },
     {
       "Key": "notLoggedInTelegram",
-      "Value":  "Kamu belum login, gunakan /login <PASSWORD>"  
+      "Value":  "Kamu belum login, gunakan /login <PASSWORD>"
+    },
+    {
+      "Key": "proxied",
+      "Value":  "Alamat IP-mu: {0} | Alamat IP Proxy: {1}"
+    },
+    {
+      "Key": "unproxied",
+      "Value":  "Alamat IP-mu: {0}"
+    },
+    {
+      "Key": "fixProxySettings",
+      "Value":  "Tekan sembarang tombol untuk menutup aplikasi, jadi kamu bisa memperbaiki pengaturan proxy-mu."
+    },
+    {
+      "Key": "usageHelp",
+      "Value":  "Argumen perintah salah! \n Penggunaan yang benar: \n {0}"
+    },
+    {
+      "Key": "loginRemainingTime",
+      "Value":  "Kamu sudah login! \n Sesi ini valid untuk: ({0}:{1} detik)"
     }
   ],
 	"PokemonStrings": [


### PR DESCRIPTION
## Short Description:
Revert some of the translation errors introduced by #5018.
New untranslated strings.

## Fixes (provide links to github issues if you can):
Using `anda` instead `kamu` to soften the language (as the previous translator notes) is backwards, because `anda` is more formal than `kamu`. It is also breaks the consistency with `-mu` suffix in some of the strings. The previous translator also seems to use "find and replace" for replacing `kamu` with `anda`, making it using uppercase mid-sentence.

#5018 also changed the information that the user has the latest version to encourage user to upgrade the program (which is pointless, because the user already has the latest version).

Update for new untranslated strings is also included. Please note that I didn't translate `proxy`, because the literal translation: `wakil`, isn't used in Indonesian (in computer context).