### PR TITLE
Fixed for #4862 Pokemons to Pokemon settings name (config.json)

### DIFF
--- a/PoGo.NecroBot.ConfigUI/MainWindow.xaml
+++ b/PoGo.NecroBot.ConfigUI/MainWindow.xaml
@@ -302,10 +302,10 @@
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
                             <Label Style="{StaticResource LineItemLabel}" Content="Evolve Pokemon at Storage Usage %" ToolTip="Decimals allowed." />
-                            <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.EvolveKeptPokemonsAtStorageUsagePercentage}" />
+                            <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.EvolveKeptPokemonAtStorageUsagePercentage}" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
-                            <CheckBox Content="Keep Pokemon which Can Evolve" IsChecked="{Binding Settings.KeepPokemonsThatCanEvolve}" ToolTip="QED." />
+                            <CheckBox Content="Keep Pokemon which Can Evolve" IsChecked="{Binding Settings.KeepPokemonThatCanEvolve}" ToolTip="QED." />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
                             <CheckBox Content="Auto-Favorite Pokemon" IsChecked="{Binding Settings.AutoFavoritePokemon}" ToolTip="QED." />

--- a/PoGo.NecroBot.ConfigUI/Models/ObservableSettings.cs
+++ b/PoGo.NecroBot.ConfigUI/Models/ObservableSettings.cs
@@ -585,21 +585,21 @@ namespace PoGo.NecroBot.ConfigUI.Models
         public static readonly DependencyProperty EvolveAllPokemonWithEnoughCandyProperty =
             DependencyProperty.Register("EvolveAllPokemonWithEnoughCandy", typeof(bool), typeof(ObservableSettings), new PropertyMetadata(false));
 
-        public double EvolveKeptPokemonsAtStorageUsagePercentage
+        public double EvolveKeptPokemonAtStorageUsagePercentage
         {
             get { return (double)GetValue(EvolveKeptPokemonsAtStorageUsagePercentageProperty); }
             set { SetValue(EvolveKeptPokemonsAtStorageUsagePercentageProperty, value); }
         }
         public static readonly DependencyProperty EvolveKeptPokemonsAtStorageUsagePercentageProperty =
-            DependencyProperty.Register("EvolveKeptPokemonsAtStorageUsagePercentage", typeof(double), typeof(ObservableSettings), new PropertyMetadata(0.0));
+            DependencyProperty.Register("EvolveKeptPokemonAtStorageUsagePercentage", typeof(double), typeof(ObservableSettings), new PropertyMetadata(0.0));
 
-        public bool KeepPokemonsThatCanEvolve
+        public bool KeepPokemonThatCanEvolve
         {
             get { return (bool)GetValue(KeepPokemonsThatCanEvolveProperty); }
             set { SetValue(KeepPokemonsThatCanEvolveProperty, value); }
         }
         public static readonly DependencyProperty KeepPokemonsThatCanEvolveProperty =
-            DependencyProperty.Register("KeepPokemonsThatCanEvolve", typeof(bool), typeof(ObservableSettings), new PropertyMetadata(false));
+            DependencyProperty.Register("KeepPokemonThatCanEvolve", typeof(bool), typeof(ObservableSettings), new PropertyMetadata(false));
 
         public float FavoriteMinIvPercentage
         {
@@ -1166,37 +1166,37 @@ namespace PoGo.NecroBot.ConfigUI.Models
         public static readonly DependencyProperty NoTransferCollectionProperty =
             DependencyProperty.Register("NoTransferCollection", typeof(ObservableCollection<PokemonToggle>), typeof(ObservableSettings), new PropertyMetadata(null));
 
-        public List<PokemonId> PokemonsToEvolve
+        public List<PokemonId> PokemonToEvolve
         {
             get { return (List<PokemonId>)GetValue(PokemonsToEvolveProperty); }
             set { SetValue(PokemonsToEvolveProperty, value); }
         }
         public static readonly DependencyProperty PokemonsToEvolveProperty =
-            DependencyProperty.Register("PokemonsToEvolve", typeof(List<PokemonId>), typeof(ObservableSettings), new PropertyMetadata(null));
+            DependencyProperty.Register("PokemonToEvolve", typeof(List<PokemonId>), typeof(ObservableSettings), new PropertyMetadata(null));
 
-        public List<PokemonId> PokemonsToLevelUp
+        public List<PokemonId> PokemonToLevelUp
         {
             get { return (List<PokemonId>)GetValue(PokemonsToLevelUpProperty); }
             set { SetValue(PokemonsToLevelUpProperty, value); }
         }
         public static readonly DependencyProperty PokemonsToLevelUpProperty =
-            DependencyProperty.Register("PokemonsToLevelUp", typeof(List<PokemonId>), typeof(ObservableSettings), new PropertyMetadata(null));
+            DependencyProperty.Register("PokemonToLevelUp", typeof(List<PokemonId>), typeof(ObservableSettings), new PropertyMetadata(null));
 
-        public List<PokemonId> PokemonsToIgnore
+        public List<PokemonId> PokemonToIgnore
         {
             get { return (List<PokemonId>)GetValue(PokemonsToIgnoreProperty); }
             set { SetValue(PokemonsToIgnoreProperty, value); }
         }
         public static readonly DependencyProperty PokemonsToIgnoreProperty =
-            DependencyProperty.Register("PokemonsToIgnore", typeof(List<PokemonId>), typeof(ObservableSettings), new PropertyMetadata(null));
+            DependencyProperty.Register("PokemonToIgnore", typeof(List<PokemonId>), typeof(ObservableSettings), new PropertyMetadata(null));
 
-        public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter
+        public Dictionary<PokemonId, TransferFilter> PokemonTransferFilter
         {
             get { return (Dictionary<PokemonId, TransferFilter>)GetValue(PokemonsTransferFilterProperty); }
             set { SetValue(PokemonsTransferFilterProperty, value); }
         }
         public static readonly DependencyProperty PokemonsTransferFilterProperty =
-            DependencyProperty.Register("PokemonsTransferFilter", typeof(Dictionary<PokemonId, TransferFilter>), typeof(ObservableSettings), new PropertyMetadata(null));
+            DependencyProperty.Register("PokemonTransferFilter", typeof(Dictionary<PokemonId, TransferFilter>), typeof(ObservableSettings), new PropertyMetadata(null));
 
         public SnipeSettings PokemonToSnipe
         {
@@ -1220,10 +1220,10 @@ namespace PoGo.NecroBot.ConfigUI.Models
         {
             ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>();
             NoTransferCollection = new ObservableCollection<PokemonToggle>();
-            PokemonsToEvolve = new List<PokemonId>();
-            PokemonsToLevelUp = new List<PokemonId>();
-            PokemonsToIgnore = new List<PokemonId>();
-            PokemonsTransferFilter = new Dictionary<PokemonId, TransferFilter>();
+            PokemonToEvolve = new List<PokemonId>();
+            PokemonToLevelUp = new List<PokemonId>();
+            PokemonToIgnore = new List<PokemonId>();
+            PokemonTransferFilter = new Dictionary<PokemonId, TransferFilter>();
             PokemonToUseMasterball = new List<PokemonId>();
         }
 
@@ -1298,8 +1298,8 @@ namespace PoGo.NecroBot.ConfigUI.Models
             res.EvolveAboveIvValue = set.EvolveAboveIvValue;
             res.EvolveAllPokemonAboveIv = set.EvolveAllPokemonAboveIv;
             res.EvolveAllPokemonWithEnoughCandy = set.EvolveAllPokemonWithEnoughCandy;
-            res.EvolveKeptPokemonsAtStorageUsagePercentage = set.EvolveKeptPokemonsAtStorageUsagePercentage;
-            res.KeepPokemonsThatCanEvolve = set.KeepPokemonsThatCanEvolve;
+            res.EvolveKeptPokemonAtStorageUsagePercentage = set.EvolveKeptPokemonAtStorageUsagePercentage;
+            res.KeepPokemonThatCanEvolve = set.KeepPokemonThatCanEvolve;
             res.AutoFavoritePokemon = set.AutoFavoritePokemon;
             res.FavoriteMinIvPercentage = set.FavoriteMinIvPercentage;
             // CAPTURE
@@ -1372,7 +1372,7 @@ namespace PoGo.NecroBot.ConfigUI.Models
             res.PokemonToSnipe = set.PokemonToSnipe;
             foreach (PokemonId pid in Enum.GetValues(typeof(PokemonId)))
             {
-                res.NoTransferCollection.Add(new PokemonToggle(pid, set.PokemonsNotToTransfer.Contains(pid)));
+                res.NoTransferCollection.Add(new PokemonToggle(pid, set.PokemonNotToTransfer.Contains(pid)));
             }
 
                 return res;
@@ -1448,8 +1448,8 @@ namespace PoGo.NecroBot.ConfigUI.Models
             gs.EvolveAboveIvValue = EvolveAboveIvValue;
             gs.EvolveAllPokemonAboveIv = EvolveAllPokemonAboveIv;
             gs.EvolveAllPokemonWithEnoughCandy = EvolveAllPokemonWithEnoughCandy;
-            gs.EvolveKeptPokemonsAtStorageUsagePercentage = EvolveKeptPokemonsAtStorageUsagePercentage;
-            gs.KeepPokemonsThatCanEvolve = KeepPokemonsThatCanEvolve;
+            gs.EvolveKeptPokemonAtStorageUsagePercentage = EvolveKeptPokemonAtStorageUsagePercentage;
+            gs.KeepPokemonThatCanEvolve = KeepPokemonThatCanEvolve;
             gs.AutoFavoritePokemon = AutoFavoritePokemon;
             gs.FavoriteMinIvPercentage = FavoriteMinIvPercentage;
             // CAPTURE
@@ -1520,8 +1520,8 @@ namespace PoGo.NecroBot.ConfigUI.Models
             gs.DumpPokemonStats = DumpPokemonStats;
             // OBJECTS & ITERATORS
             gs.PokemonToSnipe = PokemonToSnipe;
-            gs.PokemonsNotToTransfer.Clear();
-            foreach (PokemonToggle pt in NoTransferCollection) if (pt.IsChecked) gs.PokemonsNotToTransfer.Add(pt.Id);
+            gs.PokemonNotToTransfer.Clear();
+            foreach (PokemonToggle pt in NoTransferCollection) if (pt.IsChecked) gs.PokemonNotToTransfer.Add(pt.Id);
 
             return gs;
         }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -85,7 +85,7 @@ namespace PoGo.NecroBot.Logic
         double WalkingSpeedInKilometerPerHour { get; }
         bool FastSoftBanBypass { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }
-        bool KeepPokemonsThatCanEvolve { get; }
+        bool KeepPokemonThatCanEvolve { get; }
         bool TransferDuplicatePokemon { get; }
         bool TransferDuplicatePokemonOnCapture { get; }
         bool UseEggIncubators { get; }
@@ -180,19 +180,19 @@ namespace PoGo.NecroBot.Logic
         bool DetailedCountsBeforeRecycling { get; }
         bool VerboseRecycling { get; }
         double RecycleInventoryAtUsagePercentage { get; }
-        double EvolveKeptPokemonsAtStorageUsagePercentage { get; }
+        double EvolveKeptPokemonAtStorageUsagePercentage { get; }
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 
-        ICollection<PokemonId> PokemonsToEvolve { get; }
-        ICollection<PokemonId> PokemonsToLevelUp { get; }
+        ICollection<PokemonId> PokemonToEvolve { get; }
+        ICollection<PokemonId> PokemonToLevelUp { get; }
 
-        ICollection<PokemonId> PokemonsNotToTransfer { get; }
+        ICollection<PokemonId> PokemonNotToTransfer { get; }
 
         ICollection<PokemonId> PokemonsNotToCatch { get; }
 
         ICollection<PokemonId> PokemonToUseMasterball { get; }
 
-        Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter { get; }
+        Dictionary<PokemonId, TransferFilter> PokemonTransferFilter { get; }
         SnipeSettings PokemonToSnipe { get; }
 
         bool StartupWelcomeDelay { get; }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -494,10 +494,10 @@ namespace PoGo.NecroBot.Logic
 
         public TransferFilter GetPokemonTransferFilter(PokemonId pokemon)
         {
-            if (_logicSettings.PokemonsTransferFilter != null &&
-                _logicSettings.PokemonsTransferFilter.ContainsKey(pokemon))
+            if (_logicSettings.PokemonTransferFilter != null &&
+                _logicSettings.PokemonTransferFilter.ContainsKey(pokemon))
             {
-                return _logicSettings.PokemonsTransferFilter[pokemon];
+                return _logicSettings.PokemonTransferFilter[pokemon];
             }
             return new TransferFilter(_logicSettings.KeepMinCp, _logicSettings.KeepMinLvl, _logicSettings.UseKeepMinLvl, _logicSettings.KeepMinIvPercentage,
                 _logicSettings.KeepMinOperator, _logicSettings.KeepMinDuplicatePokemon);

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -360,9 +360,9 @@ namespace PoGo.NecroBot.Logic
         [DefaultValue(true)]
         public bool EvolveAllPokemonWithEnoughCandy;
         [DefaultValue(90.0)]
-        public double EvolveKeptPokemonsAtStorageUsagePercentage;
+        public double EvolveKeptPokemonAtStorageUsagePercentage;
         [DefaultValue(false)]
-        public bool KeepPokemonsThatCanEvolve;
+        public bool KeepPokemonThatCanEvolve;
         //keeping
         [DefaultValue(1250)]
         public int KeepMinCp;
@@ -542,7 +542,7 @@ namespace PoGo.NecroBot.Logic
         };
 
         
-        public List<PokemonId> PokemonsNotToTransfer = new List<PokemonId>
+        public List<PokemonId> PokemonNotToTransfer = new List<PokemonId>
         {
             //criteria: from SS Tier to A Tier + Regional Exclusive
             PokemonId.Venusaur,
@@ -583,7 +583,7 @@ namespace PoGo.NecroBot.Logic
             PokemonId.Mew
         };
 
-        public List<PokemonId> PokemonsToEvolve = new List<PokemonId>
+        public List<PokemonId> PokemonToEvolve = new List<PokemonId>
         {
             /*NOTE: keep all the end-of-line commas exept for the last one or an exception will be thrown!
             criteria: 12 candies*/
@@ -621,7 +621,7 @@ namespace PoGo.NecroBot.Logic
             //PokemonId.Goldeen,
             //PokemonId.Staryu
         };
-        public List<PokemonId> PokemonsToLevelUp = new List<PokemonId>
+        public List<PokemonId> PokemonToLevelUp = new List<PokemonId>
         {
             //criteria: from SS Tier to A Tier + Regional Exclusive
             PokemonId.Venusaur,
@@ -661,7 +661,7 @@ namespace PoGo.NecroBot.Logic
             PokemonId.Mewtwo,
             PokemonId.Mew
         };
-        public List<PokemonId> PokemonsToIgnore = new List<PokemonId>
+        public List<PokemonId> PokemonToIgnore = new List<PokemonId>
         {
             //criteria: most common
             PokemonId.Caterpie,
@@ -673,7 +673,7 @@ namespace PoGo.NecroBot.Logic
             PokemonId.Doduo
         };
 
-        public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter = new Dictionary<PokemonId, TransferFilter>
+        public Dictionary<PokemonId, TransferFilter> PokemonTransferFilter = new Dictionary<PokemonId, TransferFilter>
         {
             //criteria: based on NY Central Park and Tokyo variety + sniping optimization
             {PokemonId.Golduck, new TransferFilter(1800, 6, false, 95, "or", 1)},
@@ -841,15 +841,15 @@ namespace PoGo.NecroBot.Logic
                     settings = JsonConvert.DeserializeObject<GlobalSettings>(input, jsonSettings);
 
                     //This makes sure that existing config files dont get null values which lead to an exception
-                    foreach (var filter in settings.PokemonsTransferFilter.Where(x => x.Value.KeepMinOperator == null))
+                    foreach (var filter in settings.PokemonTransferFilter.Where(x => x.Value.KeepMinOperator == null))
                     {
                         filter.Value.KeepMinOperator = "or";
                     }
-                    foreach (var filter in settings.PokemonsTransferFilter.Where(x => x.Value.Moves == null))
+                    foreach (var filter in settings.PokemonTransferFilter.Where(x => x.Value.Moves == null))
                     {
                         filter.Value.Moves = new List<List<PokemonMove>>();
                     }
-                    foreach (var filter in settings.PokemonsTransferFilter.Where(x => x.Value.MovesOperator == null))
+                    foreach (var filter in settings.PokemonTransferFilter.Where(x => x.Value.MovesOperator == null))
                     {
                         filter.Value.MovesOperator = "or";
                     }
@@ -1345,7 +1345,7 @@ namespace PoGo.NecroBot.Logic
         public double WalkingSpeedInKilometerPerHour => _settings.WalkingSpeedInKilometerPerHour;
         public bool FastSoftBanBypass => _settings.FastSoftBanBypass;
         public bool EvolveAllPokemonWithEnoughCandy => _settings.EvolveAllPokemonWithEnoughCandy;
-        public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve;
+        public bool KeepPokemonThatCanEvolve => _settings.KeepPokemonThatCanEvolve;
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
         public bool TransferDuplicatePokemonOnCapture => _settings.TransferDuplicatePokemonOnCapture;
         public bool UseEggIncubators => _settings.UseEggIncubators;
@@ -1391,15 +1391,15 @@ namespace PoGo.NecroBot.Logic
         public bool DetailedCountsBeforeRecycling => _settings.DetailedCountsBeforeRecycling;
         public bool VerboseRecycling => _settings.VerboseRecycling;
         public double RecycleInventoryAtUsagePercentage => _settings.RecycleInventoryAtUsagePercentage;
-        public double EvolveKeptPokemonsAtStorageUsagePercentage => _settings.EvolveKeptPokemonsAtStorageUsagePercentage;
+        public double EvolveKeptPokemonAtStorageUsagePercentage => _settings.EvolveKeptPokemonAtStorageUsagePercentage;
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter => _settings.ItemRecycleFilter;
-        public ICollection<PokemonId> PokemonsToEvolve => _settings.PokemonsToEvolve;
-        public ICollection<PokemonId> PokemonsToLevelUp => _settings.PokemonsToLevelUp;
-        public ICollection<PokemonId> PokemonsNotToTransfer => _settings.PokemonsNotToTransfer;
-        public ICollection<PokemonId> PokemonsNotToCatch => _settings.PokemonsToIgnore;
+        public ICollection<PokemonId> PokemonToEvolve => _settings.PokemonToEvolve;
+        public ICollection<PokemonId> PokemonToLevelUp => _settings.PokemonToLevelUp;
+        public ICollection<PokemonId> PokemonNotToTransfer => _settings.PokemonNotToTransfer;
+        public ICollection<PokemonId> PokemonsNotToCatch => _settings.PokemonToIgnore;
 
         public ICollection<PokemonId> PokemonToUseMasterball => _settings.PokemonToUseMasterball;
-        public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter => _settings.PokemonsTransferFilter;
+        public Dictionary<PokemonId, TransferFilter> PokemonTransferFilter => _settings.PokemonTransferFilter;
         public bool StartupWelcomeDelay => _settings.StartupWelcomeDelay;
         public bool SnipeAtPokestops => _settings.SnipeAtPokestops;
 

--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -15,7 +15,7 @@ namespace PoGo.NecroBot.Logic.State
         public async Task<IState> Execute(ISession session, CancellationToken cancellationToken)
         {
             if (session.LogicSettings.EvolveAllPokemonAboveIv || session.LogicSettings.EvolveAllPokemonWithEnoughCandy 
-               || session.LogicSettings.UseLuckyEggsWhileEvolving || session.LogicSettings.KeepPokemonsThatCanEvolve)
+               || session.LogicSettings.UseLuckyEggsWhileEvolving || session.LogicSettings.KeepPokemonThatCanEvolve)
             {
                 await EvolvePokemonTask.Execute(session, cancellationToken);
             }

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -25,7 +25,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             cancellationToken.ThrowIfCancellationRequested();
 
             await session.Inventory.RefreshCachedInventory();
-            var pokemonToEvolveTask = await session.Inventory.GetPokemonToEvolve(session.LogicSettings.PokemonsToEvolve);
+            var pokemonToEvolveTask = await session.Inventory.GetPokemonToEvolve(session.LogicSettings.PokemonToEvolve);
             var pokemonToEvolve = pokemonToEvolveTask.Where(p => p != null).ToList();
 
             session.EventDispatcher.Send(new EvolveCountEvent
@@ -35,14 +35,14 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (pokemonToEvolve.Any())
             {
-                if (session.LogicSettings.KeepPokemonsThatCanEvolve)
+                if (session.LogicSettings.KeepPokemonThatCanEvolve)
                 {
                     var luckyEggMin = session.LogicSettings.UseLuckyEggsMinPokemonAmount;
                     var maxStorage = session.Profile.PlayerData.MaxPokemonStorage;
                     var totalPokemon = await session.Inventory.GetPokemons();
                     var totalEggs = await session.Inventory.GetEggs();
 
-                    var pokemonNeededInInventory = (maxStorage - totalEggs.Count()) * session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage / 100.0f;
+                    var pokemonNeededInInventory = (maxStorage - totalEggs.Count()) * session.LogicSettings.EvolveKeptPokemonAtStorageUsagePercentage / 100.0f;
                     var needPokemonToStartEvolve = Math.Round(
                         Math.Max(0,
                             Math.Min(pokemonNeededInInventory, session.Profile.PlayerData.MaxPokemonStorage)));
@@ -66,7 +66,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         session.EventDispatcher.Send(new UpdateEvent()
                         {
                             Message = session.Translation.GetTranslation(TranslationString.WaitingForMorePokemonToEvolve,
-                                pokemonToEvolve.Count, deltaCount, totalPokemon.Count(), needPokemonToStartEvolve, session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage)
+                                pokemonToEvolve.Count, deltaCount, totalPokemon.Count(), needPokemonToStartEvolve, session.LogicSettings.EvolveKeptPokemonAtStorageUsagePercentage)
                         });
                         return;
                     }

--- a/PoGo.NecroBot.Logic/Tasks/Farm.cs
+++ b/PoGo.NecroBot.Logic/Tasks/Farm.cs
@@ -25,7 +25,7 @@ namespace PoGo.NecroBot.Logic.Service
         public void Run(CancellationToken cancellationToken)
         {
             if (_session.LogicSettings.EvolveAllPokemonAboveIv || _session.LogicSettings.EvolveAllPokemonWithEnoughCandy 
-                || _session.LogicSettings.UseLuckyEggsWhileEvolving || _session.LogicSettings.KeepPokemonsThatCanEvolve)
+                || _session.LogicSettings.UseLuckyEggsWhileEvolving || _session.LogicSettings.KeepPokemonThatCanEvolve)
             {
                 EvolvePokemonTask.Execute(_session, cancellationToken).Wait(cancellationToken);
             }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -122,7 +122,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                             if (session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
                                 session.LogicSettings.EvolveAllPokemonAboveIv || 
                                 session.LogicSettings.UseLuckyEggsWhileEvolving ||
-                                session.LogicSettings.KeepPokemonsThatCanEvolve)
+                                session.LogicSettings.KeepPokemonThatCanEvolve)
                             {
                                 await EvolvePokemonTask.Execute(session, cancellationToken);
                             }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -183,7 +183,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if (session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
                         session.LogicSettings.EvolveAllPokemonAboveIv ||
                         session.LogicSettings.UseLuckyEggsWhileEvolving ||
-                        session.LogicSettings.KeepPokemonsThatCanEvolve)
+                        session.LogicSettings.KeepPokemonThatCanEvolve)
                     {
                         await EvolvePokemonTask.Execute(session, cancellationToken);
                     }

--- a/PoGo.NecroBot.Logic/Tasks/LevelUpPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/LevelUpPokemonTask.cs
@@ -42,7 +42,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             var pokemonFamilies = myPokemonFamilies.ToArray();
 
             var upgradedNumber = 0;
-            var PokemonToLevel = session.LogicSettings.PokemonsToLevelUp;
+            var PokemonToLevel = session.LogicSettings.PokemonToLevelUp;
 
             foreach (var pokemon in upgradablePokemon)
             {

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -453,7 +453,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if (session.LogicSettings.EvolveAllPokemonAboveIv ||
                         session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
                         session.LogicSettings.UseLuckyEggsWhileEvolving ||
-                        session.LogicSettings.KeepPokemonsThatCanEvolve)
+                        session.LogicSettings.KeepPokemonThatCanEvolve)
                     {
                         await EvolvePokemonTask.Execute(session, cancellationToken);
                     }

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -21,9 +21,9 @@ namespace PoGo.NecroBot.Logic.Tasks
             var duplicatePokemons =
                 await
                     session.Inventory.GetDuplicatePokemonToTransfer(
-                        session.LogicSettings.PokemonsNotToTransfer,
-                        session.LogicSettings.PokemonsToEvolve, 
-                        session.LogicSettings.KeepPokemonsThatCanEvolve,
+                        session.LogicSettings.PokemonNotToTransfer,
+                        session.LogicSettings.PokemonToEvolve, 
+                        session.LogicSettings.KeepPokemonThatCanEvolve,
                         session.LogicSettings.PrioritizeIvOverCp);
 
             var orderedPokemon = duplicatePokemons.OrderBy( poke => poke.Cp );

--- a/PoGo.NecroBot.Logic/Tasks/TransferWeakPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferWeakPokemonTask.cs
@@ -23,12 +23,12 @@ namespace PoGo.NecroBot.Logic.Tasks
             var pokemons = await session.Inventory.GetPokemons();
             var pokemonDatas = pokemons as IList<PokemonData> ?? pokemons.ToList();
             var pokemonsFiltered =
-                pokemonDatas.Where(pokemon => !session.LogicSettings.PokemonsNotToTransfer.Contains(pokemon.PokemonId))
+                pokemonDatas.Where(pokemon => !session.LogicSettings.PokemonNotToTransfer.Contains(pokemon.PokemonId))
                     .ToList().OrderBy( poke => poke.Cp );
 
-            if (session.LogicSettings.KeepPokemonsThatCanEvolve)
+            if (session.LogicSettings.KeepPokemonThatCanEvolve)
                 pokemonsFiltered =
-                    pokemonDatas.Where(pokemon => !session.LogicSettings.PokemonsToEvolve.Contains(pokemon.PokemonId))
+                    pokemonDatas.Where(pokemon => !session.LogicSettings.PokemonToEvolve.Contains(pokemon.PokemonId))
                         .ToList().OrderBy( poke => poke.Cp );
 
             var orderedPokemon = pokemonsFiltered.OrderBy( poke => poke.Cp );


### PR DESCRIPTION
Fixed for #4862 
Pokemons to Pokemon for settings (config.json)
"EvolveKeptPokemonsAtStorageUsagePercentage":
"KeepPokemonsThatCanEvolve":
"PokemonsNotToTransfer":
"PokemonsToEvolve":
"PokemonsToLevelUp":
"PokemonsToIgnore":
"PokemonsTransferFilter"