### PR TITLE
Bug fix - Fix skiplagged sniping (broken due to blacklisting of user agent)

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -522,7 +522,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 var request = WebRequest.CreateHttp(uri);
                 request.Accept = "application/json";
                 request.UserAgent =
-                    "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\r\n";
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0";
                 request.Method = "GET";
                 request.Timeout = 15000;
                 request.ReadWriteTimeout = 32000;


### PR DESCRIPTION
## Short Description:
Fixes broken skiplagged sniping.

Skiplagged started to black list the user agent we were using.  We were seeing this response:
```
{"pokemons":[], "error": "This is an illegal request, you are being watched. Either you stop immediately or we will report this to authorities."}
```

Changing the user agent fixes this.