### PR TITLE
ADD translation.ja-JP2.json

### DIFF
--- a/PoGo.NecroBot.CLI/Config/Translations/translation.ja-JP2.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.ja-JP2.json
@@ -1,0 +1,2000 @@
+{
+  "TranslationStrings": [
+    {
+      "Key": "pokeball",
+      "Value": "PokeBall"
+    },
+    {
+      "Key": "greatPokeball",
+      "Value": "GreatBall"
+    },
+    {
+      "Key": "ultraPokeball",
+      "Value": "UltraBall"
+    },
+    {
+      "Key": "masterPokeball",
+      "Value": "MasterBall"
+    },
+    {
+      "Key": "wrongAuthType",
+      "Value": "Unknown AuthType in config.json"
+    },
+    {
+      "Key": "loginInvalid",
+      "Value": "User credentials are invalid and login failed."
+    },
+    {
+      "Key": "farmPokestopsOutsideRadius",
+      "Value": "You're outside of your defined radius! Walking to start ({0}m away) in 5 seconds. Is your LastPos.ini file correct?"
+    },
+    {
+      "Key": "farmPokestopsNoUsableFound",
+      "Value": "No usable PokeStops found in your area. Is your maximum distance too small?"
+    },
+    {
+      "Key": "eventFortUsed",
+      "Value": "Name: {0} XP: {1}, Gems: {2}, Items: {3}, Lat: {4}, Long: {5}"
+    },
+    {
+      "Key": "eventFortFailed",
+      "Value": "Name: {0} INFO: Looting failed, possible softban. Unban in: {1}/{2}"
+    },
+    {
+      "Key": "eventFortTargeted",
+      "Value": "Traveling to Pokestop: {0} ({1}m) ({2} seconds)"
+    },
+    {
+      "Key": "eventProfileLogin",
+      "Value": "Playing as {0}"
+    },
+    {
+      "Key": "eventUsedIncense",
+      "Value": "Used Incense, remaining: {0}"
+    },
+    {
+      "Key": "eventUsedLuckyEgg",
+      "Value": "Used Lucky Egg, remaining: {0}"
+    },
+    {
+      "Key": "eventPokemonEvolvedSuccess",
+      "Value": "{0} successfully for {1}xp"
+    },
+    {
+      "Key": "eventPokemonEvolvedFailed",
+      "Value": "Failed {0}. Result was {1}, stopping evolving {2}"
+    },
+    {
+      "Key": "eventPokemonTransferred",
+      "Value": "{0}\t- CP: {1}  IV: {2}%   [Best CP: {3}  IV: {4}%] (Candies: {5})"
+    },
+    {
+      "Key": "eventItemRecycled",
+      "Value": "{0}x {1}"
+    },
+    {
+      "Key": "eventPokemonCaptureSuccess",
+      "Value": "({0}) | ({1}) {2} Lvl: {3} CP: ({4}/{5}) IV: {6}% | Chance: {7}% | {8}m dist | with a {9} ({10} left). | {11} EXP earned | {12} | lat: {13} long: {14}"
+    },
+    {
+      "Key": "eventPokemonCaptureFailed",
+      "Value": "({0}) | ({1}) {2} Lvl: {3} CP: ({4}/{5}) IV: {6}% | Chance: {7}% | {8}m dist | with a {9} ({10} left). | lat: {11} long: {12}"
+    },
+    {
+      "Key": "eventNoPokeballs",
+      "Value": "No Pokeballs - We missed a {0} with CP {1}"
+    },
+    {
+      "Key": "waitingForMorePokemonToEvolve",
+      "Value": "Waiting to evolve {0} Pokemon once {1} more are caught! ({2}/{3} for {4}% inventory)"
+    },
+    {
+      "Key": "useLuckyEggsMinPokemonAmountTooHigh",
+      "Value": "Lucky eggs will never be used with UseLuckyEggsMinPokemonAmount set to {0}, use <= {1} instead"
+    },
+    {
+      "Key": "catchMorePokemonToUseLuckyEgg",
+      "Value": "Catch {0} more Pokemon to use a Lucky Egg!"
+    },
+    {
+      "Key": "eventUseBerry",
+      "Value": "Used {0} | {1} remaining"
+    },
+    {
+      "Key": "itemRazzBerry",
+      "Value": "Razz Berry"
+    },
+    {
+      "Key": "catchStatusAttempt",
+      "Value": "{0} Attempt #{1}"
+    },
+    {
+      "Key": "catchStatus",
+      "Value": "{0}"
+    },
+    {
+      "Key": "candies",
+      "Value": "Candies: {0}"
+    },
+    {
+      "Key": "unhandledGpxData",
+      "Value": "Unhandled data in GPX file, attempting to skip."
+    },
+    {
+      "Key": "displayHighestsHeader",
+      "Value": "Pokemons"
+    },
+    {
+      "Key": "commonWordPerfect",
+      "Value": "perfect"
+    },
+    {
+      "Key": "commonWordName",
+      "Value": "name"
+    },
+    {
+      "Key": "commonWordUnknown",
+      "Value": "Unknown"
+    },
+    {
+      "Key": "displayHighestsCpHeader",
+      "Value": "DisplayHighestsCP"
+    },
+    {
+      "Key": "displayHighestsPerfectHeader",
+      "Value": "DisplayHighestsPerfect"
+    },
+    {
+      "Key": "displayHighestsLevelHeader",
+      "Value": "DisplayHighestsLevel"
+    },
+    {
+      "Key": "welcomeWarning",
+      "Value": "Make sure Lat & Lng are right. Exit Program if not! Lat: {0} Lng: {1}"
+    },
+    {
+      "Key": "incubatorPuttingEgg",
+      "Value": "Putting egg in incubator: {0:0.00}km left"
+    },
+    {
+      "Key": "incubatorStatusUpdate",
+      "Value": "Incubator status update: {0:0.00}km left"
+    },
+    {
+      "Key": "incubatorEggHatched",
+      "Value": "Incubated egg has hatched: {0} | Lvl: {1} CP: ({2}/{3}) IV: {4}%"
+    },
+    {
+      "Key": "logEntryError",
+      "Value": "ERROR"
+    },
+    {
+      "Key": "logEntryAttention",
+      "Value": "ATTENTION"
+    },
+    {
+      "Key": "logEntryInfo",
+      "Value": "INFO"
+    },
+    {
+      "Key": "logEntryPokestop",
+      "Value": "POKESTOP"
+    },
+    {
+      "Key": "logEntryFarming",
+      "Value": "FARMING"
+    },
+    {
+      "Key": "logEntrySniper",
+      "Value": "SNIPER"
+    },
+    {
+      "Key": "logEntryRecycling",
+      "Value": "RECYCLING"
+    },
+    {
+      "Key": "logEntryPkmn",
+      "Value": "PKMN"
+    },
+    {
+      "Key": "logEntryTransfered",
+      "Value": "TRANSFERRED"
+    },
+    {
+      "Key": "logEntryEvolved",
+      "Value": "EVOLVED"
+    },
+    {
+      "Key": "logEntryBerry",
+      "Value": "BERRY"
+    },
+    {
+      "Key": "logEntryEgg",
+      "Value": "EGG"
+    },
+    {
+      "Key": "logEntryDebug",
+      "Value": "DEBUG"
+    },
+    {
+      "Key": "logEntryUpdate",
+      "Value": "UPDATE"
+    },
+    {
+      "Key": "logEntryNew",
+      "Value": "NEW"
+    },
+    {
+      "Key": "logEntrySoftBan",
+      "Value": "SOFTBAN"
+    },
+    {
+      "Key": "loggingIn",
+      "Value": "Logging in using {0}"
+    },
+    {
+      "Key": "ptcOffline",
+      "Value": "PTC Servers are probably down OR your credentials are wrong. Try google"
+    },
+    {
+      "Key": "accessTokenExpired",
+      "Value": "PTC Login Token expired. Relogging..."
+    },
+    {
+      "Key": "invalidResponse",
+      "Value": "Received an invalid response from Niantic server"
+    },
+    {
+      "Key": "tryingAgainIn",
+      "Value": "Trying again in {0} seconds..."
+    },
+    {
+      "Key": "accountNotVerified",
+      "Value": "Account not verified! Exiting..."
+    },
+    {
+      "Key": "openingGoogleDevicePage",
+      "Value": "Opening Google Device page. Please paste the code using CTRL+V"
+    },
+    {
+      "Key": "couldntCopyToClipboard",
+      "Value": "Couldnt copy to clipboard, do it manually"
+    },
+    {
+      "Key": "couldntCopyToClipboard2",
+      "Value": "Goto: {0} & enter {1}"
+    },
+    {
+      "Key": "realisticTravelDetected",
+      "Value": "Detected realistic Traveling , using Default Settings inside config.json"
+    },
+    {
+      "Key": "notRealisticTravel",
+      "Value": "Not realistic Traveling at {0}, using last saved LastPos.ini"
+    },
+    {
+      "Key": "coordinatesAreInvalid",
+      "Value": "Coordinates in \"LastPos.ini\" file are invalid, using the default coordinates"
+    },
+    {
+      "Key": "gotUpToDateVersion",
+      "Value": "Perfect! You already have the newest Version {0}"
+    },
+    {
+      "Key": "autoUpdaterDisabled",
+      "Value": "AutoUpdater is disabled. Get the latest release from: {0}\n "
+    },
+    {
+      "Key": "downloadingUpdate",
+      "Value": "Downloading and apply Update..."
+    },
+    {
+      "Key": "finishedDownloadingRelease",
+      "Value": "Finished downloading newest Release..."
+    },
+    {
+      "Key": "finishedUnpackingFiles",
+      "Value": "Finished unpacking files..."
+    },
+    {
+      "Key": "finishedTransferringConfig",
+      "Value": "Finished transferring your config to the new version..."
+    },
+    {
+      "Key": "updateFinished",
+      "Value": "Update finished, you can close this window now."
+    },
+    {
+      "Key": "lookingForIncensePokemon",
+      "Value": "Looking for incense Pokemon..."
+    },
+    {
+      "Key": "lookingForPokemon",
+      "Value": "Looking for Pokemon..."
+    },
+    {
+      "Key": "lookingForLurePokemon",
+      "Value": "Looking for lure Pokemon..."
+    },
+    {
+      "Key": "pokemonSkipped",
+      "Value": "Skipped {0}"
+    },
+    {
+      "Key": "zeroPokeballInv",
+      "Value": "You have no pokeballs in your inventory, no more Pokemon can be caught!"
+    },
+    {
+      "Key": "currentPokeballInv",
+      "Value": "Pokeballs: {0} | Greatballs: {1} | Ultraballs: {2} | Masterballs: {3}"
+    },
+    {
+      "Key": "currentPotionInv",
+      "Value": "Potions: {0} | SuperPotions: {1} | HyperPotions: {2} | MaxPotions: {3}"
+    },
+    {
+      "Key": "currentReviveInv",
+      "Value": "Revives: {0} | MaxRevives: {1}"
+    },
+    {
+      "Key": "currentMiscItemInv",
+      "Value": "Berries: {0} | Incense: {1} | LuckyEggs: {2} | Lures: {3}"
+    },
+    {
+      "Key": "maxItemsCombinedOverMaxItemStorage",
+      "Value": "[Configuration Invalid] Your maximum items combined (balls+potions+revives={0}) is over your max item storage ({1})"
+    },
+    {
+      "Key": "recyclingQuietly",
+      "Value": "Recycling Quietly..."
+    },
+    {
+      "Key": "invFullTransferring",
+      "Value": "Pokemon Inventory is full, transferring Pokemon..."
+    },
+    {
+      "Key": "invFullTransferManually",
+      "Value": "Pokemon Inventory is full! Please transfer Pokemon manually or set TransferDuplicatePokemon to true in settings..."
+    },
+    {
+      "Key": "invFullPokestopLooting",
+      "Value": "Inventory is full, no items looted!"
+    },
+    {
+      "Key": "encounterProblem",
+      "Value": "Encounter problem: {0}"
+    },
+    {
+      "Key": "encounterProblemLurePokemon",
+      "Value": "Encounter problem: Lure Pokemon {0}"
+    },
+    {
+      "Key": "desiredDestTooFar",
+      "Value": "Your desired destination of {0}, {1} is too far from your current position of {2}, {3}"
+    },
+    {
+      "Key": "pokemonRename",
+      "Value": "Pokemon {0} ({1}) renamed from {2} to {3}."
+    },
+    {
+      "Key": "pokemonFavorite",
+      "Value": "{0}% perfect {1} (CP {2}) *favorited*."
+    },
+    {
+      "Key": "pokemonIgnoreFilter",
+      "Value": "[Pokemon ignore filter] - Ignoring {0} as defined in settings"
+    },
+    {
+      "Key": "catchStatusAttempt",
+      "Value": "CatchAttempt"
+    },
+    {
+      "Key": "catchStatusError",
+      "Value": "CatchError"
+    },
+    {
+      "Key": "catchStatusEscape",
+      "Value": "CatchEscape"
+    },
+    {
+      "Key": "catchStatusFlee",
+      "Value": "CatchFlee"
+    },
+    {
+      "Key": "catchStatusMissed",
+      "Value": "CatchMissed"
+    },
+    {
+      "Key": "catchStatusSuccess",
+      "Value": "CatchSuccess"
+    },
+    {
+      "Key": "catchTypeNormal",
+      "Value": "Normal"
+    },
+    {
+      "Key": "catchTypeLure",
+      "Value": "Lure"
+    },
+    {
+      "Key": "catchTypeIncense",
+      "Value": "Incense"
+    },
+    {
+      "Key": "webSocketFailStart",
+      "Value": "Failed to start WebSocketServer on port : {0}"
+    },
+    {
+      "Key": "statsTemplateString",
+      "Value": "{0} - Runtime {1} - Lvl: {2} | EXP/H: {3:n0} | P/H: {4:n0} | Stardust: {5:n0} | Transferred: {6:n0} | Recycled: {7:n0}"
+    },
+    {
+      "Key": "profileStatsTemplateString",
+      "Value": "----- LVL {0} | {1} ----- \n Experience: {2}/{3} \n Pokemons caught: {4} \n Pokemons deployed: {5} \n Pokestops visited: {6} \n Eggs hatched: {7} \n Pokemons evolved: {8} \n Pokedex entries: {9} \n KM walked: {10}  \n Pokemons: {11}/{12}"
+    },
+    {
+      "Key": "showPokeTemplate",
+      "Value": "\n CP: {0} | IV: {1}% | Name: {2}"
+    },
+    {
+      "Key": "helpTemplate",
+      "Value": "Commands: \n \n /top <cp/iv> <amount> - Shows you top Pokemons. \n /all <cp/iv> - Shows you all Pokemons. \n /profile - Shows you profile. \n /loc - Shows you location. \n /items - Shows your items. \n /status - Shows you the Status of the Bot. \n /pokedex - Shows you Pokedex "
+    },
+    {
+      "Key": "statsXpTemplateString",
+      "Value": "{0} (Advance in {1}h {2}m | {3:n0}/{4:n0} XP)"
+    },
+    {
+      "Key": "requireInputText",
+      "Value": "Program will continue after the key press..."
+    },
+    {
+      "Key": "googleTwoFactorAuth",
+      "Value": "As you have Google Two Factor Auth enabled, you will need to insert an App Specific Password into the auth.json"
+    },
+    {
+      "Key": "googleTwoFactorAuthExplanation",
+      "Value": "Opening Google App-Passwords. Please make a new App Password (use Other as Device)"
+    },
+    {
+      "Key": "googleError",
+      "Value": "Make sure you have entered the right Email & Password."
+    },
+    {
+      "Key": "googleOffline",
+      "Value": "Google servers are probably down, Please be patient and start the bot later."
+    },
+    {
+      "Key": "missingCredentialsGoogle",
+      "Value": "You need to fill out GoogleUsername and GooglePassword in auth.json!"
+    },
+    {
+      "Key": "missingCredentialsPtc",
+      "Value": "You need to fill out PtcUsername and PtcPassword in auth.json!"
+    },
+    {
+      "Key": "snipeScan",
+      "Value": "Scanning for Snipeable Pokemon at {0}..."
+    },
+    {
+      "Key": "snipeScanEx",
+      "Value": "Sniping a {0} with {1} IV at {2}..."
+    },
+    {
+      "Key": "noPokemonToSnipe",
+      "Value": "Did not find a Pokemon within the Location, pokemon despawned?"
+    },
+    {
+      "Key": "notEnoughPokeballsToSnipe",
+      "Value": "Not enough Pokeballs to start sniping! ({0}/{1})"
+    },
+    {
+      "Key": "displayHighestMove1Header",
+      "Value": "MOVE1"
+    },
+    {
+      "Key": "displayHighestMove2Header",
+      "Value": "MOVE2"
+    },
+    {
+      "Key": "displayHighestCandy",
+      "Value": "Candy"
+    },
+    {
+      "Key": "ipBannedError",
+      "Value": "Connection refused. Your IP might have been Blacklisted by Niantic. Exiting.."
+    },
+    {
+      "Key": "noEggsAvailable",
+      "Value": "No Eggs Available"
+    },
+    {
+      "Key": "useLuckyEggActive",
+      "Value": "Lucky Egg Already Active"
+    },
+    {
+      "Key": "usedLuckyEgg",
+      "Value": "Used Lucky Egg"
+    },
+    {
+      "Key": "useLuckyEggAmount",
+      "Value": "Lucky Eggs in Inventory: {0}"
+    },
+    {
+      "Key": "noIncenseAvailable",
+      "Value": "No Incense Available"
+    },
+    {
+      "Key": "useIncenseActive",
+      "Value": "Incense Already Active"
+    },
+    {
+      "Key": "useIncenseAmount",
+      "Value": "Incense in Inventory: {0}"
+    },
+    {
+      "Key": "usedIncense",
+      "Value": "Used an Incense"
+    },
+    {
+      "Key": "amountPkmSeenCaught",
+      "Value": "Amount of Pokemon Seen: {0}/151, Amount of Pokemon Caught: {1}/151"
+    },
+    {
+      "Key": "pkmPotentialEvolveCount",
+      "Value": "Potential Evolutions: {0}"
+    },
+    {
+      "Key": "pkmNotEnoughRessources",
+      "Value": "Pokemon Upgrade Failed Not Enough Resources"
+    },
+    {
+      "Key": "snipeServerOffline",
+      "Value": "Sniping server is offline. Skipping..."
+    },
+    {
+      "Key": "firstStartPrompt",
+      "Value": "This is your first start, would you like to begin setup? {0}/{1}"
+    },
+    {
+      "Key": "firstStartLanguagePrompt",
+      "Value": "Would you like to change the default language? {0}/{1}"
+    },
+    {
+      "Key": "firstStartLanguageCodePrompt",
+      "Value": "Please enter a new language code"
+    },
+    {
+      "Key": "firstStartLanguageConfirm",
+      "Value": "Language Code Applied: {0}"
+    },
+    {
+      "Key": "promptError",
+      "Value": "[INPUT ERROR] Error with input, please enter '{0}' or '{1}"
+    },
+    {
+      "Key": "firstStartAutoGenSettings",
+      "Value": "Config/Auth file automatically generated and must be completed before continuing"
+    },
+    {
+      "Key": "firstStartSetupAccount",
+      "Value": "### Setting up new USER ACCOUNT ###"
+    },
+    {
+      "Key": "firstStartSetupTypePrompt",
+      "Value": "Please choose an account type: {0}/{1}"
+    },
+    {
+      "Key": "firstStartSetupTypeConfirm",
+      "Value": "Chosen Account Type: {0}"
+    },
+    {
+      "Key": "firstStartSetupTypePromptError",
+      "Value": "[ERROR] submitted an incorrect account type, please choose '{0}' or '{1}'"
+    },
+    {
+      "Key": "firstStartSetupUsernamePrompt",
+      "Value": "Please enter a Username"
+    },
+    {
+      "Key": "firstStartSetupUsernameConfirm",
+      "Value": "Accepted username: {0}"
+    },
+    {
+      "Key": "firstStartSetupPasswordPrompt",
+      "Value": "Please enter a Password"
+    },
+    {
+      "Key": "firstStartSetupPasswordConfirm",
+      "Value": "Accepted password: {0}"
+    },
+    {
+      "Key": "firstStartAccountCompleted",
+      "Value": "### User Account Completed ###"
+    },
+    {
+      "Key": "firstStartDefaultLocationPrompt",
+      "Value": "Would you like to setup a new Default Location? {0}/{1}"
+    },
+    {
+      "Key": "firstStartDefaultLocationSet",
+      "Value": "Default Location Applied"
+    },
+    {
+      "Key": "firstStartDefaultLocation",
+      "Value": "### Setting Default Position ###"
+    },
+    {
+      "Key": "firstStartSetupDefaultLocationError",
+      "Value": "[ERROR] Please input only a VALUE for example: {0}"
+    },
+    {
+      "Key": "firstStartSetupDefaultLatPrompt",
+      "Value": "Please enter a Latitude (Right click to paste)"
+    },
+    {
+      "Key": "firstStartSetupDefaultLatConfirm",
+      "Value": "Lattitude accepted: {0}"
+    },
+    {
+      "Key": "firstStartSetupDefaultLongPrompt",
+      "Value": "Please enter a Longitude (Right click to paste)"
+    },
+    {
+      "Key": "firstStartSetupDefaultLongConfirm",
+      "Value": "Longitude accepted: {0}"
+    },
+    {
+      "Key": "softBanBypassed",
+      "Value": "Successfully bypassed!"
+    },
+    {
+      "Key": "firstStartSetupCompleted",
+      "Value": "### COMPLETED CONFIG SETUP ###"
+    },
+    {
+      "Key": "pokedexCatchedTelegram",
+      "Value": "--- Pokedex catched --- \n"
+    },
+    {
+      "Key": "pokedexPokemonCatchedTelegram",
+      "Value": "#{0} Name: {1} | Catched: {2} | Encountered: {3} \n"
+    },
+    {
+      "Key": "pokedexNeededTelegram",
+      "Value": "--- Pokedex needed --- \n"
+    },
+    {
+      "Key": "pokedexPokemonNeededTelegram",
+      "Value": "#{0}# Name: {1} \n"
+    }
+  ],
+  "PokemonStrings": [
+    {
+      "Key": "bulbasaur",
+      "Value": "ﾌｼｷﾞﾀﾞﾈ"
+    },
+    {
+      "Key": "ivysaur",
+      "Value": "ﾌｼｷﾞｿｳ"
+    },
+    {
+      "Key": "venusaur",
+      "Value": "ﾌｼｷﾞﾊﾞﾅ"
+    },
+    {
+      "Key": "charmander",
+      "Value": "ﾋﾄｶｹﾞ"
+    },
+    {
+      "Key": "charmeleon",
+      "Value": "ﾘｻﾞｰﾄﾞ"
+    },
+    {
+      "Key": "charizard",
+      "Value": "ﾘｻﾞｰﾄﾞﾝ"
+    },
+    {
+      "Key": "squirtle",
+      "Value": "ｾﾞﾆｶﾞﾒ"
+    },
+    {
+      "Key": "wartortle",
+      "Value": "ｶﾒｰﾙ"
+    },
+    {
+      "Key": "blastoise",
+      "Value": "ｶﾒｯｸｽ"
+    },
+    {
+      "Key": "caterpie",
+      "Value": "ｷｬﾀﾋﾟｰ"
+    },
+    {
+      "Key": "metapod",
+      "Value": "ﾄﾗﾝｾﾙ"
+    },
+    {
+      "Key": "butterfree",
+      "Value": "ﾊﾞﾀﾌﾘｰ"
+    },
+    {
+      "Key": "weedle",
+      "Value": "ﾋﾞｰﾄﾞﾙ"
+    },
+    {
+      "Key": "kakuna",
+      "Value": "ｺｸｰﾝ"
+    },
+    {
+      "Key": "beedrill",
+      "Value": "ｽﾋﾟｱｰ"
+    },
+    {
+      "Key": "pidgey",
+      "Value": "ﾎﾟｯﾎﾟ"
+    },
+    {
+      "Key": "pidgeotto",
+      "Value": "ﾋﾟｼﾞｮﾝ"
+    },
+    {
+      "Key": "pidgeot",
+      "Value": "ﾋﾟｼﾞｮｯﾄ"
+    },
+    {
+      "Key": "rattata",
+      "Value": "ｺﾗｯﾀ"
+    },
+    {
+      "Key": "raticate",
+      "Value": "ﾗｯﾀ"
+    },
+    {
+      "Key": "spearow",
+      "Value": "ｵﾆｽｽﾞﾒ"
+    },
+    {
+      "Key": "fearow",
+      "Value": "ｵﾆﾄﾞﾘﾙ"
+    },
+    {
+      "Key": "ekans",
+      "Value": "ｱｰﾎﾞ"
+    },
+    {
+      "Key": "arbok",
+      "Value": "ｱｰﾎﾞｯｸ"
+    },
+    {
+      "Key": "pikachu",
+      "Value": "ﾋﾟｶﾁｭｳ"
+    },
+    {
+      "Key": "raichu",
+      "Value": "ﾗｲﾁｭｳ"
+    },
+    {
+      "Key": "sandshrew",
+      "Value": "ｻﾝﾄﾞ"
+    },
+    {
+      "Key": "sandslash",
+      "Value": "ｻﾝﾄﾞﾊﾟﾝ"
+    },
+    {
+      "Key": "nidoranFemale",
+      "Value": "ﾆﾄﾞﾗﾝ♀"
+    },
+    {
+      "Key": "nidorina",
+      "Value": "ﾆﾄﾞﾘｰﾅ"
+    },
+    {
+      "Key": "nidoqueen",
+      "Value": "ﾆﾄﾞｸｲﾝ"
+    },
+    {
+      "Key": "nidoranMale",
+      "Value": "ﾆﾄﾞﾗﾝ♂"
+    },
+    {
+      "Key": "nidorino",
+      "Value": "ﾆﾄﾞﾘｰﾉ"
+    },
+    {
+      "Key": "nidoking",
+      "Value": "ﾆﾄﾞｷﾝｸﾞ"
+    },
+    {
+      "Key": "clefairy",
+      "Value": "ﾋﾟｯﾋﾟ"
+    },
+    {
+      "Key": "clefable",
+      "Value": "ﾋﾟｸｼｰ"
+    },
+    {
+      "Key": "vulpix",
+      "Value": "ﾛｺﾝ"
+    },
+    {
+      "Key": "ninetales",
+      "Value": "ｷｭｳｺﾝ"
+    },
+    {
+      "Key": "jigglypuff",
+      "Value": "ﾌﾟﾘﾝ"
+    },
+    {
+      "Key": "wigglytuff",
+      "Value": "ﾌﾟｸﾘﾝ"
+    },
+    {
+      "Key": "zubat",
+      "Value": "ｽﾞﾊﾞｯﾄ"
+    },
+    {
+      "Key": "golbat",
+      "Value": "ｺﾞﾙﾊﾞｯﾄ"
+    },
+    {
+      "Key": "oddish",
+      "Value": "ﾅｿﾞﾉｸｻ"
+    },
+    {
+      "Key": "gloom",
+      "Value": "ｸｻｲﾊﾅ"
+    },
+    {
+      "Key": "vileplume",
+      "Value": "ﾗﾌﾚｼｱ"
+    },
+    {
+      "Key": "paras",
+      "Value": "ﾊﾟﾗｽ"
+    },
+    {
+      "Key": "parasect",
+      "Value": "ﾊﾟﾗｾｸﾄ"
+    },
+    {
+      "Key": "venonat",
+      "Value": "ｺﾝﾊﾟﾝ"
+    },
+    {
+      "Key": "venomoth",
+      "Value": "ﾓﾙﾌｫﾝ"
+    },
+    {
+      "Key": "diglett",
+      "Value": "ﾃﾞｨｸﾞﾀﾞ"
+    },
+    {
+      "Key": "dugtrio",
+      "Value": "ﾀﾞｸﾄﾘｵ"
+    },
+    {
+      "Key": "meowth",
+      "Value": "ﾆｭｰｽ"
+    },
+    {
+      "Key": "persian",
+      "Value": "ﾍﾟﾙｼｱﾝ"
+    },
+    {
+      "Key": "psyduck",
+      "Value": "ｺﾀﾞｯｸ"
+    },
+    {
+      "Key": "golduck",
+      "Value": "ｺﾞﾙﾀﾞｯｸ"
+    },
+    {
+      "Key": "mankey",
+      "Value": "ﾏﾝｷｰ"
+    },
+    {
+      "Key": "primeape",
+      "Value": "ｵｺﾘｻﾞﾙ"
+    },
+    {
+      "Key": "growlithe",
+      "Value": "ｶﾞｰﾃﾞｨ"
+    },
+    {
+      "Key": "arcanine",
+      "Value": "ｳｲﾝﾃﾞｨ"
+    },
+    {
+      "Key": "poliwag",
+      "Value": "ﾆｮﾛﾓ"
+    },
+    {
+      "Key": "poliwhirl",
+      "Value": "ﾆｮﾛｿﾞ"
+    },
+    {
+      "Key": "poliwrath",
+      "Value": "ﾆｮﾛﾎﾞﾝ"
+    },
+    {
+      "Key": "abra",
+      "Value": "ｹｰｼｨ"
+    },
+    {
+      "Key": "kadabra",
+      "Value": "ﾕﾝｹﾞﾗｰ"
+    },
+    {
+      "Key": "alakazam",
+      "Value": "ﾌｰﾃﾞｨﾝ"
+    },
+    {
+      "Key": "machop",
+      "Value": "ﾜﾝﾘｷｰ"
+    },
+    {
+      "Key": "machoke",
+      "Value": "ｺﾞｰﾘｷｰ"
+    },
+    {
+      "Key": "machamp",
+      "Value": "ｶｲﾘｷｰ"
+    },
+    {
+      "Key": "bellsprout",
+      "Value": "ﾏﾀﾞﾂﾎﾞﾐ"
+    },
+    {
+      "Key": "weepinbell",
+      "Value": "ｳﾂﾄﾞﾝ"
+    },
+    {
+      "Key": "victreebel",
+      "Value": "ｳﾂﾎﾞｯﾄ"
+    },
+    {
+      "Key": "tentacool",
+      "Value": "ﾒﾉｸﾗｹﾞ"
+    },
+    {
+      "Key": "tentacruel",
+      "Value": "ﾄﾞｸｸﾗｹﾞ"
+    },
+    {
+      "Key": "geodude",
+      "Value": "ｲｼﾂﾌﾞﾃ"
+    },
+    {
+      "Key": "graveler",
+      "Value": "ｺﾞﾛｰﾝ"
+    },
+    {
+      "Key": "golem",
+      "Value": "ｺﾞﾛｰﾆｬ"
+    },
+    {
+      "Key": "ponyta",
+      "Value": "ﾎﾟﾆｰﾀ"
+    },
+    {
+      "Key": "rapidash",
+      "Value": "ｷﾞｬﾛｯﾌﾟ"
+    },
+    {
+      "Key": "slowpoke",
+      "Value": "ﾔﾄﾞﾝ"
+    },
+    {
+      "Key": "slowbro",
+      "Value": "ﾔﾄﾞﾗﾝ"
+    },
+    {
+      "Key": "magnemite",
+      "Value": "ｺｲﾙ"
+    },
+    {
+      "Key": "magneton",
+      "Value": "ﾚｱｺｲﾙ"
+    },
+    {
+      "Key": "farfetchd",
+      "Value": "ｶﾓﾈｷﾞ"
+    },
+    {
+      "Key": "doduo",
+      "Value": "ﾄﾞｰﾄﾞｰ"
+    },
+    {
+      "Key": "dodrio",
+      "Value": "ﾄﾞｰﾄﾞﾘｵ"
+    },
+    {
+      "Key": "seel",
+      "Value": "ﾊﾟｳﾜｳ"
+    },
+    {
+      "Key": "dewgong",
+      "Value": "ｼﾞｭｺﾞﾝ"
+    },
+    {
+      "Key": "grimer",
+      "Value": "ﾍﾞﾄﾍﾞﾀｰ"
+    },
+    {
+      "Key": "muk",
+      "Value": "ﾍﾞﾄﾍﾞﾄﾝ"
+    },
+    {
+      "Key": "shellder",
+      "Value": "ｼｪﾙﾀﾞｰ"
+    },
+    {
+      "Key": "cloyster",
+      "Value": "ﾊﾟﾙｼｪﾝ"
+    },
+    {
+      "Key": "gastly",
+      "Value": "ｺﾞｰｽ"
+    },
+    {
+      "Key": "haunter",
+      "Value": "ｺﾞｰｽﾄ"
+    },
+    {
+      "Key": "gengar",
+      "Value": "ｹﾞﾝｶﾞｰ"
+    },
+    {
+      "Key": "onix",
+      "Value": "ｲﾜｰｸ"
+    },
+    {
+      "Key": "drowzee",
+      "Value": "ｽﾘｰﾌﾟ"
+    },
+    {
+      "Key": "hypno",
+      "Value": "ｽﾘｰﾊﾟｰ"
+    },
+    {
+      "Key": "krabby",
+      "Value": "ｸﾗﾌﾞ"
+    },
+    {
+      "Key": "kingler",
+      "Value": "ｷﾝｸﾞﾗｰ"
+    },
+    {
+      "Key": "voltorb",
+      "Value": "ﾋﾞﾘﾘﾀﾞﾏ"
+    },
+    {
+      "Key": "electrode",
+      "Value": "ﾏﾙﾏｲﾝ"
+    },
+    {
+      "Key": "exeggcute",
+      "Value": "ﾀﾏﾀﾏ"
+    },
+    {
+      "Key": "exeggutor",
+      "Value": "ﾅｯｼｰ"
+    },
+    {
+      "Key": "cubone",
+      "Value": "ｶﾗｶﾗ"
+    },
+    {
+      "Key": "marowak",
+      "Value": "ｶﾞﾗｶﾞﾗ"
+    },
+    {
+      "Key": "hitmonlee",
+      "Value": "ｻﾜﾑﾗｰ"
+    },
+    {
+      "Key": "hitmonchan",
+      "Value": "ｴﾋﾞﾜﾗｰ"
+    },
+    {
+      "Key": "lickitung",
+      "Value": "ﾍﾞﾛﾘﾝｶﾞ"
+    },
+    {
+      "Key": "koffing",
+      "Value": "ﾄﾞｶﾞｰｽ"
+    },
+    {
+      "Key": "weezing",
+      "Value": "ﾏﾀﾄﾞｶﾞｽ"
+    },
+    {
+      "Key": "rhyhorn",
+      "Value": "ｻｲﾎｰﾝ"
+    },
+    {
+      "Key": "rhydon",
+      "Value": "ｻｲﾄﾞﾝ"
+    },
+    {
+      "Key": "chansey",
+      "Value": "ﾗｯｷｰ"
+    },
+    {
+      "Key": "tangela",
+      "Value": "ﾓﾝｼﾞｬﾗ"
+    },
+    {
+      "Key": "kangaskhan",
+      "Value": "ｶﾞﾙｰﾗ"
+    },
+    {
+      "Key": "horsea",
+      "Value": "ﾀｯﾂｰ"
+    },
+    {
+      "Key": "seadra",
+      "Value": "ｼｰﾄﾞﾗ"
+    },
+    {
+      "Key": "goldeen",
+      "Value": "ﾄｻｷﾝﾄ"
+    },
+    {
+      "Key": "seaking",
+      "Value": "ｱｽﾞﾏｵｳ"
+    },
+    {
+      "Key": "staryu",
+      "Value": "ﾋﾄﾃﾞﾏﾝ"
+    },
+    {
+      "Key": "starmie",
+      "Value": "ｽﾀｰﾐｰ"
+    },
+    {
+      "Key": "mrMime",
+      "Value": "ﾊﾞﾘﾔｰﾄﾞ"
+    },
+    {
+      "Key": "scyther",
+      "Value": "ｽﾄﾗｲｸ"
+    },
+    {
+      "Key": "jynx",
+      "Value": "ﾙｰｼﾞｭﾗ"
+    },
+    {
+      "Key": "electabuzz",
+      "Value": "ｴﾚﾌﾞｰ"
+    },
+    {
+      "Key": "magmar",
+      "Value": "ﾌﾞｰﾊﾞｰ"
+    },
+    {
+      "Key": "pinsir",
+      "Value": "ｶｲﾛｽ"
+    },
+    {
+      "Key": "tauros",
+      "Value": "ｹﾝﾀﾛｽ"
+    },
+    {
+      "Key": "magikarp",
+      "Value": "ｺｲｷﾝｸﾞ"
+    },
+    {
+      "Key": "gyarados",
+      "Value": "ｷﾞｬﾗﾄﾞｽ"
+    },
+    {
+      "Key": "lapras",
+      "Value": "ﾗﾌﾟﾗｽ"
+    },
+    {
+      "Key": "ditto",
+      "Value": "ﾒﾀﾓﾝ"
+    },
+    {
+      "Key": "eevee",
+      "Value": "ｲｰﾌﾞｲ"
+    },
+    {
+      "Key": "vaporeon",
+      "Value": "ｼｬﾜｰｽﾞ"
+    },
+    {
+      "Key": "jolteon",
+      "Value": "ｻﾝﾀﾞｰｽ"
+    },
+    {
+      "Key": "flareon",
+      "Value": "ﾌﾞｰｽﾀｰ"
+    },
+    {
+      "Key": "porygon",
+      "Value": "ﾎﾟﾘｺﾞﾝ"
+    },
+    {
+      "Key": "omanyte",
+      "Value": "ｵﾑﾅｲﾄ"
+    },
+    {
+      "Key": "omastar",
+      "Value": "ｵﾑｽﾀｰ"
+    },
+    {
+      "Key": "kabuto",
+      "Value": "ｶﾌﾞﾄ"
+    },
+    {
+      "Key": "kabutops",
+      "Value": "ｶﾌﾞﾄﾌﾟｽ"
+    },
+    {
+      "Key": "aerodactyl",
+      "Value": "ﾌﾟﾃﾗ"
+    },
+    {
+      "Key": "snorlax",
+      "Value": "ｶﾋﾞｺﾞﾝ"
+    },
+    {
+      "Key": "articuno",
+      "Value": "ﾌﾘｰｻﾞｰ"
+    },
+    {
+      "Key": "zapdos",
+      "Value": "ｻﾝﾀﾞｰ"
+    },
+    {
+      "Key": "moltres",
+      "Value": "ﾌｧｲﾔｰ"
+    },
+    {
+      "Key": "dratini",
+      "Value": "ﾐﾆﾘｭｳ"
+    },
+    {
+      "Key": "dragonair",
+      "Value": "ﾊｸﾘｭｳ"
+    },
+    {
+      "Key": "dragonite",
+      "Value": "ｶｲﾘｭｰ"
+    },
+    {
+      "Key": "mewtwo",
+      "Value": "ﾐｭｳﾂｰ"
+    },
+    {
+      "Key": "mew",
+      "Value": "ﾐｭｳ"
+    }
+  ],
+  "PokemonMovesetStrings": [
+    {
+      "Key": "moveUnset",
+      "Value": "ﾅｼ"
+    },
+    {
+      "Key": "thunderShock",
+      "Value": "ﾃﾞﾝｷｼｮｯｸ"
+    },
+    {
+      "Key": "quickAttack",
+      "Value": "ﾃﾞﾝｺｳｾｯｶ"
+    },
+    {
+      "Key": "scratch",
+      "Value": "ﾋｯｶｸ"
+    },
+    {
+      "Key": "ember",
+      "Value": "ﾋﾉｺ"
+    },
+    {
+      "Key": "vineWhip",
+      "Value": "ﾂﾙﾉﾑﾁ"
+    },
+    {
+      "Key": "tackle",
+      "Value": "ﾀｲｱﾀﾘ"
+    },
+    {
+      "Key": "razorLeaf",
+      "Value": "ﾊｯﾊﾟｶｯﾀｰ"
+    },
+    {
+      "Key": "takeDown",
+      "Value": "ﾄｯｼﾝ"
+    },
+    {
+      "Key": "waterGun",
+      "Value": "ﾐｽﾞﾃﾞｯﾎﾟｳ"
+    },
+    {
+      "Key": "bite",
+      "Value": "ｶﾐﾂｸ"
+    },
+    {
+      "Key": "pound",
+      "Value": "ﾊﾀｸ"
+    },
+    {
+      "Key": "doubleSlap",
+      "Value": "ｵｳﾌｸﾋﾞﾝﾀ"
+    },
+    {
+      "Key": "wrap",
+      "Value": "ﾏｷﾂｸ"
+    },
+    {
+      "Key": "hyperBeam",
+      "Value": "ﾊｶｲｺｳｾﾝ"
+    },
+    {
+      "Key": "lick",
+      "Value": "ｼﾀﾃﾞﾅﾒﾙ"
+    },
+    {
+      "Key": "darkPulse",
+      "Value": "ｱｸﾉﾊﾄﾞｳ"
+    },
+    {
+      "Key": "smog",
+      "Value": "ｽﾓｯｸﾞ"
+    },
+    {
+      "Key": "sludge",
+      "Value": "ﾍﾄﾞﾛｺｳｹﾞｷ"
+    },
+    {
+      "Key": "metalClaw",
+      "Value": "ﾒﾀﾙｸﾛｰ"
+    },
+    {
+      "Key": "viceGrip",
+      "Value": "ﾊｻﾑ"
+    },
+    {
+      "Key": "flameWheel",
+      "Value": "ｶｴﾝｸﾞﾙﾏ"
+    },
+    {
+      "Key": "megahorn",
+      "Value": "ﾒｶﾞﾎｰﾝ"
+    },
+    {
+      "Key": "wingAttack",
+      "Value": "ﾂﾊﾞｻﾃﾞｳﾂ"
+    },
+    {
+      "Key": "flamethrower",
+      "Value": "ｶｴﾝﾎｳｼｬ"
+    },
+    {
+      "Key": "suckerPunch",
+      "Value": "ﾌｲｳﾁ"
+    },
+    {
+      "Key": "dig",
+      "Value": "ｱﾅｦﾎﾙ"
+    },
+    {
+      "Key": "lowKick",
+      "Value": "ｹﾀｸﾞﾘ"
+    },
+    {
+      "Key": "crossChop",
+      "Value": "ｸﾛｽﾁｮｯﾌﾟ"
+    },
+    {
+      "Key": "psychoCut",
+      "Value": "ｻｲｺｶｯﾀｰ"
+    },
+    {
+      "Key": "psybeam",
+      "Value": "ｻｲｹｺｳｾﾝ"
+    },
+    {
+      "Key": "earthquake",
+      "Value": "ｼﾞｼﾝ"
+    },
+    {
+      "Key": "stoneEdge",
+      "Value": "ｽﾄｰﾝｴｯｼﾞ"
+    },
+    {
+      "Key": "icePunch",
+      "Value": "ﾚｲﾄｳﾊﾟﾝﾁ"
+    },
+    {
+      "Key": "heartStamp",
+      "Value": "ﾊｰﾄｽﾀﾝﾌﾟ"
+    },
+    {
+      "Key": "discharge",
+      "Value": "ﾎｳﾃﾞﾝ"
+    },
+    {
+      "Key": "flashCannon",
+      "Value": "ﾗｽﾀｰｶﾉﾝ"
+    },
+    {
+      "Key": "peck",
+      "Value": "ﾂﾂｸ"
+    },
+    {
+      "Key": "drillPeck",
+      "Value": "ﾄﾞﾘﾙｸﾁﾊﾞｼ"
+    },
+    {
+      "Key": "iceBeam",
+      "Value": "ﾚｲﾄｳﾋﾞｰﾑ"
+    },
+    {
+      "Key": "blizzard",
+      "Value": "ﾌﾌﾞｷ"
+    },
+    {
+      "Key": "airSlash",
+      "Value": "ｴｱｽﾗｯｼｭ"
+    },
+    {
+      "Key": "heatWave",
+      "Value": "ﾈｯﾌﾟｳ"
+    },
+    {
+      "Key": "twineedle",
+      "Value": "ﾀﾞﾌﾞﾙﾆｰﾄﾞﾙ"
+    },
+    {
+      "Key": "poisonJab",
+      "Value": "ﾄﾞｸﾂﾞｷ"
+    },
+    {
+      "Key": "aerialAce",
+      "Value": "ﾂﾊﾞﾒｶﾞｴｼ"
+    },
+    {
+      "Key": "drillRun",
+      "Value": "ﾄﾞﾘﾙﾗｲﾅｰ"
+    },
+    {
+      "Key": "petalBlizzard",
+      "Value": "ﾊﾅﾌﾌﾞｷ"
+    },
+    {
+      "Key": "megaDrain",
+      "Value": "ﾒｶﾞﾄﾞﾚｲﾝ"
+    },
+    {
+      "Key": "bugBuzz",
+      "Value": "ﾑｼﾉｻｻﾞﾒｷ"
+    },
+    {
+      "Key": "poisonFang",
+      "Value": "ﾄﾞｸﾄﾞｸﾉｷﾊﾞ"
+    },
+    {
+      "Key": "nightSlash",
+      "Value": "ﾂｼﾞｷﾞﾘ"
+    },
+    {
+      "Key": "slash",
+      "Value": "ｷﾘｻｸ"
+    },
+    {
+      "Key": "bubbleBeam",
+      "Value": "ﾊﾞﾌﾞﾙｺｳｾﾝ"
+    },
+    {
+      "Key": "submission",
+      "Value": "ｼﾞｺﾞｸｸﾞﾙﾏ"
+    },
+    {
+      "Key": "karateChop",
+      "Value": "ｶﾗﾃﾁｮｯﾌﾟ"
+    },
+    {
+      "Key": "lowSweep",
+      "Value": "ﾛｰｷｯｸ"
+    },
+    {
+      "Key": "aquaJet",
+      "Value": "ｱｸｱｼﾞｪｯﾄ"
+    },
+    {
+      "Key": "aquaTail",
+      "Value": "ｱｸｱﾃｰﾙ"
+    },
+    {
+      "Key": "seedBomb",
+      "Value": "ﾀﾈﾊﾞｸﾀﾞﾝ"
+    },
+    {
+      "Key": "psyshock",
+      "Value": "ｻｲｺｼｮｯｸ"
+    },
+    {
+      "Key": "rockThrow",
+      "Value": "ｲﾜｵﾄｼ"
+    },
+    {
+      "Key": "ancientPower",
+      "Value": "ｹﾞﾝｼﾉﾁｶﾗ"
+    },
+    {
+      "Key": "rockTomb",
+      "Value": "ｶﾞﾝｾｷﾌｳｼﾞ"
+    },
+    {
+      "Key": "rockSlide",
+      "Value": "ｲﾜﾅﾀﾞﾚ"
+    },
+    {
+      "Key": "powerGem",
+      "Value": "ﾊﾟﾜｰｼﾞｪﾑ"
+    },
+    {
+      "Key": "shadowSneak",
+      "Value": "ｶｹﾞｳﾁ"
+    },
+    {
+      "Key": "shadowPunch",
+      "Value": "ｼｬﾄﾞｰﾊﾟﾝﾁ"
+    },
+    {
+      "Key": "shadowClaw",
+      "Value": "ｼｬﾄﾞｰｸﾛｰ"
+    },
+    {
+      "Key": "ominousWind",
+      "Value": "ｱﾔｼｲｶｾﾞ"
+    },
+    {
+      "Key": "shadowBall",
+      "Value": "ｼｬﾄﾞｰﾎﾞｰﾙ"
+    },
+    {
+      "Key": "bulletPunch",
+      "Value": "ﾊﾞﾚｯﾄﾊﾟﾝﾁ"
+    },
+    {
+      "Key": "magnetBomb",
+      "Value": "ﾏｸﾞﾈｯﾄﾎﾞﾑ"
+    },
+    {
+      "Key": "steelWing",
+      "Value": "SteelWing"
+    },
+    {
+      "Key": "ironHead",
+      "Value": "ｱｲｱﾝﾍｯﾄﾞ"
+    },
+    {
+      "Key": "parabolicCharge",
+      "Value": "ﾊﾟﾗﾎﾞﾗﾁｬｰｼﾞ"
+    },
+    {
+      "Key": "spark",
+      "Value": "ｽﾊﾟｰｸ"
+    },
+    {
+      "Key": "thunderPunch",
+      "Value": "ｶﾐﾅﾘﾊﾟﾝﾁ"
+    },
+    {
+      "Key": "thunder",
+      "Value": "ｶﾐﾅﾘ"
+    },
+    {
+      "Key": "thunderbolt",
+      "Value": "10ﾏﾝﾎﾞﾙﾄ"
+    },
+    {
+      "Key": "twister",
+      "Value": "ﾀﾂﾏｷ"
+    },
+    {
+      "Key": "dragonBreath",
+      "Value": "ﾘｭｳﾉｲﾌﾞｷ"
+    },
+    {
+      "Key": "dragonPulse",
+      "Value": "ﾘｭｳﾉﾊﾄﾞｳ"
+    },
+    {
+      "Key": "dragonClaw",
+      "Value": "ﾄﾞﾗｺﾞﾝｸﾛｰ"
+    },
+    {
+      "Key": "disarmingVoice",
+      "Value": "ﾁｬｰﾑﾎﾞｲｽ"
+    },
+    {
+      "Key": "drainingKiss",
+      "Value": "ﾄﾞﾚｲﾝｷｯｽ"
+    },
+    {
+      "Key": "dazzlingGleam",
+      "Value": "ﾏｼﾞｶﾙｼｬｲﾝ"
+    },
+    {
+      "Key": "moonblast",
+      "Value": "ﾑｰﾝﾌｫｰｽ"
+    },
+    {
+      "Key": "playRough",
+      "Value": "ｼﾞｬﾚﾂｸ"
+    },
+    {
+      "Key": "crossPoison",
+      "Value": "ｸﾛｽﾎﾟｲｽﾞﾝ"
+    },
+    {
+      "Key": "sludgeBomb",
+      "Value": "ﾍﾄﾞﾛﾊﾞｸﾀﾞﾝ"
+    },
+    {
+      "Key": "sludgeWave",
+      "Value": "ﾍﾄﾞﾛｳｪｰﾌﾞ"
+    },
+    {
+      "Key": "gunkShot",
+      "Value": "ﾀﾞｽﾄｼｭｰﾄ"
+    },
+    {
+      "Key": "mudShot",
+      "Value": "ﾏｯﾄﾞｼｮｯﾄ"
+    },
+    {
+      "Key": "boneClub",
+      "Value": "ﾎﾈｺﾝﾎﾞｳ"
+    },
+    {
+      "Key": "bulldoze",
+      "Value": "ｼﾞﾅﾗｼ"
+    },
+    {
+      "Key": "mudBomb",
+      "Value": "ﾄﾞﾛﾊﾞｸﾀﾞﾝ"
+    },
+    {
+      "Key": "furyCutter",
+      "Value": "ﾚﾝｿﾞｸｷﾞﾘ"
+    },
+    {
+      "Key": "bugBite",
+      "Value": "ﾑｼｸｲ"
+    },
+    {
+      "Key": "signalBeam",
+      "Value": "ｼｸﾞﾅﾙﾋﾞｰﾑ"
+    },
+    {
+      "Key": "xScissor",
+      "Value": "ｼｻﾞｰｸﾛｽ"
+    },
+    {
+      "Key": "flameCharge",
+      "Value": "ﾆﾄﾛﾁｬｰｼﾞ"
+    },
+    {
+      "Key": "flameBurst",
+      "Value": "ﾊｼﾞｹﾙﾎﾉｵ"
+    },
+    {
+      "Key": "fireBlast",
+      "Value": "ﾀﾞｲﾓﾝｼﾞ"
+    },
+    {
+      "Key": "brine",
+      "Value": "ｼｵﾐｽﾞ"
+    },
+    {
+      "Key": "waterPulse",
+      "Value": "ﾐｽﾞﾉﾊﾄﾞｳ"
+    },
+    {
+      "Key": "scald",
+      "Value": "ﾈｯﾄｳ"
+    },
+    {
+      "Key": "hydroPump",
+      "Value": "ﾊｲﾄﾞﾛﾎﾟﾝﾌﾟ"
+    },
+    {
+      "Key": "psychic",
+      "Value": "ｻｲｺｷﾈｼｽ"
+    },
+    {
+      "Key": "psystrike",
+      "Value": "ｻｲｺﾌﾞﾚｲｸ"
+    },
+    {
+      "Key": "iceShard",
+      "Value": "ｺｵﾘﾉﾂﾌﾞﾃ"
+    },
+    {
+      "Key": "icyWind",
+      "Value": "ｺｺﾞｴﾙｶｾﾞ"
+    },
+    {
+      "Key": "frostBreath",
+      "Value": "ｺｵﾘﾉｲﾌﾞｷ"
+    },
+    {
+      "Key": "absorb",
+      "Value": "ｽｲﾄﾙ"
+    },
+    {
+      "Key": "gigaDrain",
+      "Value": "ｷﾞｶﾞﾄﾞﾚｲﾝ"
+    },
+    {
+      "Key": "firePunch",
+      "Value": "ﾎﾉｵﾉﾊﾟﾝﾁ"
+    },
+    {
+      "Key": "solarBeam",
+      "Value": "ｿｰﾗｰﾋﾞｰﾑ"
+    },
+    {
+      "Key": "leafBlade",
+      "Value": "ﾘｰﾌﾌﾞﾚｰﾄﾞ"
+    },
+    {
+      "Key": "powerWhip",
+      "Value": "ﾊﾟﾜｰｳｨｯﾌﾟ"
+    },
+    {
+      "Key": "splash",
+      "Value": "ﾊﾈﾙ"
+    },
+    {
+      "Key": "acid",
+      "Value": "ﾖｳｶｲｴｷ"
+    },
+    {
+      "Key": "airCutter",
+      "Value": "ｴｱｶｯﾀｰ"
+    },
+    {
+      "Key": "hurricane",
+      "Value": "ﾎﾞｳﾌｳ"
+    },
+    {
+      "Key": "brickBreak",
+      "Value": "ｶﾜﾗﾜﾘ"
+    },
+    {
+      "Key": "cut",
+      "Value": "ｲｱｲｷﾞﾘ"
+    },
+    {
+      "Key": "swift",
+      "Value": "ｽﾋﾟｰﾄﾞｽﾀｰ"
+    },
+    {
+      "Key": "hornAttack",
+      "Value": "ﾂﾉﾃﾞﾂｸ"
+    },
+    {
+      "Key": "stomp",
+      "Value": "ﾌﾐﾂｹ"
+    },
+    {
+      "Key": "headbutt",
+      "Value": "ｽﾞﾂｷ"
+    },
+    {
+      "Key": "hyperFang",
+      "Value": "ﾋｯｻﾂﾏｴﾊﾞ"
+    },
+    {
+      "Key": "slam",
+      "Value": "ﾀﾀｷﾂｹﾙ"
+    },
+    {
+      "Key": "bodySlam",
+      "Value": "ﾉｼｶｶﾘ"
+    },
+    {
+      "Key": "rest",
+      "Value": "ﾈﾑﾙ"
+    },
+    {
+      "Key": "struggle",
+      "Value": "ﾜﾙｱｶﾞｷ"
+    },
+    {
+      "Key": "scaldBlastoise",
+      "Value": "ﾈｯﾄｳ(ｶﾒｯｸｽ)"
+    },
+    {
+      "Key": "hydroPumpBlastoise",
+      "Value": "ﾊｲﾄﾞﾛﾎﾟﾝﾌﾟ(ｶﾒｯｸｽ)"
+    },
+    {
+      "Key": "wrapGreen",
+      "Value": "ﾏｷﾂｸ(ﾐﾄﾞﾘ)"
+    },
+    {
+      "Key": "wrapPink",
+      "Value": "ﾏｷﾂｸ(ﾋﾟﾝｸ)"
+    },
+    {
+      "Key": "furyCutterFast",
+      "Value": "ﾚﾝｿﾞｸｷﾞﾘS"
+    },
+    {
+      "Key": "bugBiteFast",
+      "Value": "ﾑｼｸｲS"
+    },
+    {
+      "Key": "biteFast",
+      "Value": "ｶﾐﾂｸS"
+    },
+    {
+      "Key": "suckerPunchFast",
+      "Value": "ﾌｲｳﾁS"
+    },
+    {
+      "Key": "dragonBreathFast",
+      "Value": "ﾘｭｳﾉｲﾌﾞｷS"
+    },
+    {
+      "Key": "thunderShockFast",
+      "Value": "ﾃﾞﾝｷｼｮｯｸS"
+    },
+    {
+      "Key": "sparkFast",
+      "Value": "ｽﾊﾟｰｸS"
+    },
+    {
+      "Key": "lowKickFast",
+      "Value": "ｹﾀｸﾞﾘS"
+    },
+    {
+      "Key": "karateChopFast",
+      "Value": "ｶﾗﾃﾁｮｯﾌﾟS"
+    },
+    {
+      "Key": "emberFast",
+      "Value": "ﾋﾉｺS"
+    },
+    {
+      "Key": "wingAttackFast",
+      "Value": "ﾂﾊﾞｻﾃﾞｳﾂS"
+    },
+    {
+      "Key": "peckFast",
+      "Value": "ﾂﾂｸS"
+    },
+    {
+      "Key": "lickFast",
+      "Value": "ｼﾀﾃﾞﾅﾒﾙS"
+    },
+    {
+      "Key": "shadowClawFast",
+      "Value": "ｼｬﾄﾞｰｸﾛｰS"
+    },
+    {
+      "Key": "vineWhipFast",
+      "Value": "ﾂﾙﾉﾑﾁS"
+    },
+    {
+      "Key": "razorLeafFast",
+      "Value": "ﾊｯﾊﾟｶｯﾀｰS"
+    },
+    {
+      "Key": "mudShotFast",
+      "Value": "ﾏｯﾄﾞｼｮｯﾄS"
+    },
+    {
+      "Key": "iceShardFast",
+      "Value": "ｺｵﾘﾉﾂﾌﾞﾃS"
+    },
+    {
+      "Key": "frostBreathFast",
+      "Value": "ｺｵﾘﾉｲﾌﾞｷS"
+    },
+    {
+      "Key": "quickAttackFast",
+      "Value": "ﾃﾞﾝｺｳｾｯｶS"
+    },
+    {
+      "Key": "scratchFast",
+      "Value": "ﾋｯｶｸS"
+    },
+    {
+      "Key": "tackleFast",
+      "Value": "ﾀｲｱﾀﾘS"
+    },
+    {
+      "Key": "poundFast",
+      "Value": "ﾊﾀｸS"
+    },
+    {
+      "Key": "cutFast",
+      "Value": "ｲｱｲｷﾞﾘS"
+    },
+    {
+      "Key": "poisonJabFast",
+      "Value": "ﾄﾞｸﾂﾞｷS"
+    },
+    {
+      "Key": "acidFast",
+      "Value": "ﾖｳｶｲｴｷS"
+    },
+    {
+      "Key": "psychoCutFast",
+      "Value": "ｻｲｺｶｯﾀｰS"
+    },
+    {
+      "Key": "rockThrowFast",
+      "Value": "ｲﾜｵﾄｼS"
+    },
+    {
+      "Key": "metalClawFast",
+      "Value": "ﾒﾀﾙｸﾛｰS"
+    },
+    {
+      "Key": "bulletPunchFast",
+      "Value": "ﾊﾞﾚｯﾄﾊﾟﾝﾁS"
+    },
+    {
+      "Key": "waterGunFast",
+      "Value": "ﾐｽﾞﾃﾞｯﾎﾟｳS"
+    },
+    {
+      "Key": "splashFast",
+      "Value": "ﾊﾈﾙS"
+    },
+    {
+      "Key": "waterGunFastBlastoise",
+      "Value": "ﾐｽﾞﾃﾞｯﾎﾟｳS(ｶﾒｯｸｽ)"
+    },
+    {
+      "Key": "mudSlapFast",
+      "Value": "ﾄﾞﾛｶｹS"
+    },
+    {
+      "Key": "zenHeadbuttFast",
+      "Value": "ｼﾈﾝﾉｽﾞﾂｷS"
+    },
+    {
+      "Key": "confusionFast",
+      "Value": "ﾈﾝﾘｷS"
+    },
+    {
+      "Key": "poisonStingFast",
+      "Value": "ﾄﾞｸﾊﾞﾘS"
+    },
+    {
+      "Key": "bubbleFast",
+      "Value": "ｱﾜS"
+    },
+    {
+      "Key": "feintAttackFast",
+      "Value": "ﾀﾞﾏｼｳﾁS"
+    },
+    {
+      "Key": "steelWingFast",
+      "Value": "ﾊｶﾞﾈﾉﾂﾊﾞｻS"
+    },
+    {
+      "Key": "fireFangFast",
+      "Value": "ﾎﾉｵﾉｷﾊﾞS"
+    },
+    {
+      "Key": "rockSmashFast",
+      "Value": "ｲﾜｸﾀﾞｷS"
+    }
+  ]
+}


### PR DESCRIPTION
Currently, Necrobot is There is a bug in the display of the double-byte character.
Therefore, we have Japanese the only Pokemon name and moves.
Does not cause a bug for that is described in the 1-byte character.
Please use here until the bug is avoided.