### PR TITLE
Color settings for console messages.

### DIFF
--- a/PoGo.NecroBot.ConfigUI/MainWindow.xaml
+++ b/PoGo.NecroBot.ConfigUI/MainWindow.xaml
@@ -512,6 +512,78 @@
                                 <Label Style="{StaticResource LineItemLabel}" Content="Telegram Password" ToolTip="QED." />
                                 <TextBox Style="{StaticResource LineItemTextBoxMd}" Text="{Binding Settings.TelegramPassword}" />
                             </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Error Message Color" ToolTip="Change the Error message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.ErrorColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Warning Message Color" ToolTip="Change the Warning message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.WarningColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Pokestop Message Color" ToolTip="Change the Pokestop message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.PokestopColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Farming Message Color" ToolTip="Change the Farming message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.FarmingColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Sniper Message Color" ToolTip="Change the Sniper message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.SniperColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Recycling Message Color" ToolTip="Change the Recycling message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.RecyclingColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Berry Message Color" ToolTip="Change the Berry message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.BerryColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Caught Message Color" ToolTip="Change the Caught message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.CaughtColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Flee Message Color" ToolTip="Change the Flee message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.FleeColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Transfer Message Color" ToolTip="Change the Transfer message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.TransferColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Evolve Message Color" ToolTip="Change the Evolve message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.EvolveColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Egg Message Color" ToolTip="Change the Egg message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.EggColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Update Message Color" ToolTip="Change the Update message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.UpdateColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Info Message Color" ToolTip="Change the Info message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.InfoColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="New Message Color" ToolTip="Change the New message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.NewColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="SoftBan Message Color" ToolTip="Change the SoftBan message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.SoftBanColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="LevelUpColor Message Color" ToolTip="Change the LevelUpColor message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.LevelUpColor}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Style="{StaticResource LineItemPanel}">
+                                <Label Style="{StaticResource LineItemLabel}" Content="Debug Message Color" ToolTip="Change the Debug message color in the console." />
+                                <TextBox Style="{StaticResource LineItemTextBoxSm}" Text="{Binding Settings.DebugColor}" />
+                        </StackPanel>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>

--- a/PoGo.NecroBot.ConfigUI/Models/ObservableSettings.cs
+++ b/PoGo.NecroBot.ConfigUI/Models/ObservableSettings.cs
@@ -1150,145 +1150,148 @@ namespace PoGo.NecroBot.ConfigUI.Models
         
         public string ErrorColor
         {
-            get { return (string)GetValue(ErrorColor); }
-            set { SetValue(ErrorColor, value); }
+            get { return (string)GetValue(ErrorColorProperty); }
+            set { SetValue(ErrorColorProperty, value); }
         }
-        public static readonly DependencyProperty ErrorColor =
-            DependencyProperty.Register("ErrorColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty ErrorColorProperty =
+            DependencyProperty.Register("ErrorColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+       
         public string WarningColor
         {
-            get { return (string)GetValue(WarningColor); }
-            set { SetValue(WarningColor, value); }
+            get { return (string)GetValue(WarningColorProperty); }
+            set { SetValue(WarningColorProperty, value); }
         }
-        public static readonly DependencyProperty WarningColor =
-            DependencyProperty.Register("WarningColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty WarningColorProperty =
+            DependencyProperty.Register("WarningColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        
         public string PokestopColor
         {
-            get { return (string)GetValue(PokestopColor); }
-            set { SetValue(PokestopColor, value); }
+            get { return (string)GetValue(PokestopColorProperty); }
+            set { SetValue(PokestopColorProperty, value); }
         }
-        public static readonly DependencyProperty PokestopColor =
-            DependencyProperty.Register("PokestopColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty PokestopColorProperty =
+            DependencyProperty.Register("PokestopColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
         
         public string FarmingColor
         {
-            get { return (string)GetValue(FarmingColor); }
-            set { SetValue(FarmingColor, value); }
+            get { return (string)GetValue(FarmingColorProperty); }
+            set { SetValue(FarmingColorProperty, value); }
         }
-        public static readonly DependencyProperty FarmingColor =
-            DependencyProperty.Register("FarmingColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty FarmingColorProperty =
+            DependencyProperty.Register("FarmingColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
         
         public string SniperColor
         {
-            get { return (string)GetValue(SniperColor); }
-            set { SetValue(SniperColor, value); }
+            get { return (string)GetValue(SniperColorProperty); }
+            set { SetValue(SniperColorProperty, value); }
         }
-        public static readonly DependencyProperty SniperColor =
-            DependencyProperty.Register("SniperColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty SniperColorProperty =
+            DependencyProperty.Register("SniperColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
         
         public string RecyclingColor
         {
-            get { return (string)GetValue(RecyclingColor); }
-            set { SetValue(RecyclingColor, value); }
+            get { return (string)GetValue(RecyclingColorProperty); }
+            set { SetValue(RecyclingColorProperty, value); }
         }
-        public static readonly DependencyProperty RecyclingColor =
-            DependencyProperty.Register("RecyclingColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty RecyclingColorProperty =
+            DependencyProperty.Register("RecyclingColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
         
         public string BerryColor
         {
-            get { return (string)GetValue(BerryColor); }
-            set { SetValue(BerryColor, value); }
+            get { return (string)GetValue(BerryColorProperty); }
+            set { SetValue(BerryColorProperty, value); }
         }
-        public static readonly DependencyProperty BerryColor =
-            DependencyProperty.Register("BerryColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty BerryColorProperty =
+            DependencyProperty.Register("BerryColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
         
         public string CaughtColor
         {
-            get { return (string)GetValue(CaughtColor); }
-            set { SetValue(CaughtColor, value); }
+            get { return (string)GetValue(CaughtColorProperty); }
+            set { SetValue(CaughtColorProperty, value); }
         }
-        public static readonly DependencyProperty CaughtColor =
-            DependencyProperty.Register("CaughtColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty CaughtColorProperty =
+            DependencyProperty.Register("CaughtColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
         
         public string FleeColor
         {
-            get { return (string)GetValue(FleeColor); }
-            set { SetValue(FleeColor, value); }
+            get { return (string)GetValue(FleeColorProperty); }
+            set { SetValue(FleeColorProperty, value); }
         }
-        public static readonly DependencyProperty FleeColor =
-            DependencyProperty.Register("FleeColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty FleeColorProperty =
+            DependencyProperty.Register("FleeColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string TransferColor
         {
-            get { return (string)GetValue(TransferColor); }
-            set { SetValue(TransferColor, value); }
+            get { return (string)GetValue(TransferColorProperty); }
+            set { SetValue(TransferColorProperty, value); }
         }
-        public static readonly DependencyProperty TransferColor =
-            DependencyProperty.Register("TransferColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty TransferColorProperty =
+            DependencyProperty.Register("TransferColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string EvolveColor
         {
-            get { return (string)GetValue(EvolveColor); }
-            set { SetValue(EvolveColor, value); }
+            get { return (string)GetValue(EvolveColorProperty); }
+            set { SetValue(EvolveColorProperty, value); }
         }
-        public static readonly DependencyProperty EvolveColor =
-            DependencyProperty.Register("EvolveColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty EvolveColorProperty =
+            DependencyProperty.Register("EvolveColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string EggColor
         {
-            get { return (string)GetValue(EggColor); }
-            set { SetValue(EggColor, value); }
+            get { return (string)GetValue(EggColorProperty); }
+            set { SetValue(EggColorProperty, value); }
         }
-        public static readonly DependencyProperty EggColor =
-            DependencyProperty.Register("EggColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty EggColorProperty =
+            DependencyProperty.Register("EggColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string UpdateColor
         {
-            get { return (string)GetValue(UpdateColor); }
-            set { SetValue(UpdateColor, value); }
+            get { return (string)GetValue(UpdateColorProperty); }
+            set { SetValue(UpdateColorProperty, value); }
         }
-        public static readonly DependencyProperty UpdateColor =
-            DependencyProperty.Register("UpdateColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty UpdateColorProperty =
+            DependencyProperty.Register("UpdateColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string InfoColor
         {
-            get { return (string)GetValue(InfoColor); }
-            set { SetValue(InfoColor, value); }
+            get { return (string)GetValue(InfoColorProperty); }
+            set { SetValue(InfoColorProperty, value); }
         }
-        public static readonly DependencyProperty InfoColor =
-            DependencyProperty.Register("InfoColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty InfoColorProperty =
+            DependencyProperty.Register("InfoColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string NewColor
         {
-            get { return (string)GetValue(NewColor); }
-            set { SetValue(NewColor, value); }
+            get { return (string)GetValue(NewColorProperty); }
+            set { SetValue(NewColorProperty, value); }
         }
-        public static readonly DependencyProperty NewColor =
-            DependencyProperty.Register("NewColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty NewColorProperty =
+            DependencyProperty.Register("NewColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string SoftBanColor
         {
-            get { return (string)GetValue(SoftBanColor); }
-            set { SetValue(SoftBanColor, value); }
+            get { return (string)GetValue(SoftBanColorProperty); }
+            set { SetValue(SoftBanColorProperty, value); }
         }
-        public static readonly DependencyProperty SoftBanColor =
-            DependencyProperty.Register("SoftBanColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty SoftBanColorProperty =
+            DependencyProperty.Register("SoftBanColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string LevelUpColor
         {
-            get { return (string)GetValue(LevelUpColor); }
-            set { SetValue(LevelUpColor, value); }
+            get { return (string)GetValue(LevelUpColorProperty); }
+            set { SetValue(LevelUpColorProperty, value); }
         }
-        public static readonly DependencyProperty LevelUpColor =
-            DependencyProperty.Register("LevelUpColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty LevelUpColorProperty =
+            DependencyProperty.Register("LevelUpColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
                 
         public string DebugColor
         {
-            get { return (string)GetValue(DebugColor); }
-            set { SetValue(DebugColor, value); }
+            get { return (string)GetValue(DebugColorProperty); }
+            set { SetValue(DebugColorProperty, value); }
         }
-        public static readonly DependencyProperty DebugColor =
-            DependencyProperty.Register("DebugColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty DebugColorProperty =
+            DependencyProperty.Register("DebugColorProperty", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        
         #endregion MISC Properties
 
 

--- a/PoGo.NecroBot.ConfigUI/Models/ObservableSettings.cs
+++ b/PoGo.NecroBot.ConfigUI/Models/ObservableSettings.cs
@@ -1536,6 +1536,24 @@ namespace PoGo.NecroBot.ConfigUI.Models
             res.AmountOfPokemonToDisplayOnStart = set.AmountOfPokemonToDisplayOnStart;
             res.DetailedCountsBeforeRecycling = set.DetailedCountsBeforeRecycling;
             res.DumpPokemonStats = set.DumpPokemonStats;
+            res.ErrorColor = set.ErrorColor;
+            res.WarningColor = set.WarningColor;
+            res.PokestopColor = set.PokestopColor;
+            res.FarmingColor = set.FarmingColor;
+            res.SniperColor = set.SniperColor;
+            res.RecyclingColor = set.RecyclingColor;
+            res.BerryColor = set.BerryColor;
+            res.CaughtColor = set.CaughtColor;
+            res.FleeColor = set.FleeColor;
+            res.TransferColor = set.TransferColor;
+            res.EvolveColor = set.EvolveColor;
+            res.EggColor = set.EggColor;
+            res.UpdateColor = set.UpdateColor;
+            res.InfoColor = set.InfoColor;
+            res.NewColor = set.NewColor;
+            res.SoftBanColor = set.SoftBanColor;
+            res.LevelUpColor = set.LevelUpColor;
+            res.DebugColor = set.DebugColor;
             // OBJECTS & ITERATORS
             res.PokemonToSnipe = set.PokemonToSnipe;
             foreach (PokemonId pid in Enum.GetValues(typeof(PokemonId)))
@@ -1696,6 +1714,24 @@ namespace PoGo.NecroBot.ConfigUI.Models
             gs.AmountOfPokemonToDisplayOnStart = AmountOfPokemonToDisplayOnStart;
             gs.DetailedCountsBeforeRecycling = DetailedCountsBeforeRecycling;
             gs.DumpPokemonStats = DumpPokemonStats;
+            gs.ErrorColor = ErrorColor;
+            gs.WarningColor = WarningColor;
+            gs.PokestopColor = PokestopColor;
+            gs.FarmingColor = FarmingColor;
+            gs.SniperColor = SniperColor;
+            gs.RecyclingColor = RecyclingColor;
+            gs.BerryColor = BerryColor;
+            gs.CaughtColor = CaughtColor;
+            gs.FleeColor = FleeColor;
+            gs.TransferColor = TransferColor;
+            gs.EvolveColor = EvolveColor;
+            gs.EggColor = EggColor;
+            gs.UpdateColor = UpdateColor;
+            gs.InfoColor = InfoColor;
+            gs.NewColor = NewColor;
+            gs.SoftBanColor = SoftBanColor;
+            gs.LevelUpColor = LevelUpColor;
+            gs.DebugColor = DebugColor;
             // OBJECTS & ITERATORS
             gs.PokemonToSnipe = PokemonToSnipe;
             gs.PokemonsNotToTransfer.Clear();

--- a/PoGo.NecroBot.ConfigUI/Models/ObservableSettings.cs
+++ b/PoGo.NecroBot.ConfigUI/Models/ObservableSettings.cs
@@ -1147,7 +1147,148 @@ namespace PoGo.NecroBot.ConfigUI.Models
         }
         public static readonly DependencyProperty DumpPokemonStatsProperty =
             DependencyProperty.Register("DumpPokemonStats", typeof(bool), typeof(ObservableSettings), new PropertyMetadata(false));
-
+        
+        public string ErrorColor
+        {
+            get { return (string)GetValue(ErrorColor); }
+            set { SetValue(ErrorColor, value); }
+        }
+        public static readonly DependencyProperty ErrorColor =
+            DependencyProperty.Register("ErrorColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public string WarningColor
+        {
+            get { return (string)GetValue(WarningColor); }
+            set { SetValue(WarningColor, value); }
+        }
+        public static readonly DependencyProperty WarningColor =
+            DependencyProperty.Register("WarningColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        public string PokestopColor
+        {
+            get { return (string)GetValue(PokestopColor); }
+            set { SetValue(PokestopColor, value); }
+        }
+        public static readonly DependencyProperty PokestopColor =
+            DependencyProperty.Register("PokestopColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        
+        public string FarmingColor
+        {
+            get { return (string)GetValue(FarmingColor); }
+            set { SetValue(FarmingColor, value); }
+        }
+        public static readonly DependencyProperty FarmingColor =
+            DependencyProperty.Register("FarmingColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        
+        public string SniperColor
+        {
+            get { return (string)GetValue(SniperColor); }
+            set { SetValue(SniperColor, value); }
+        }
+        public static readonly DependencyProperty SniperColor =
+            DependencyProperty.Register("SniperColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        
+        public string RecyclingColor
+        {
+            get { return (string)GetValue(RecyclingColor); }
+            set { SetValue(RecyclingColor, value); }
+        }
+        public static readonly DependencyProperty RecyclingColor =
+            DependencyProperty.Register("RecyclingColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        
+        public string BerryColor
+        {
+            get { return (string)GetValue(BerryColor); }
+            set { SetValue(BerryColor, value); }
+        }
+        public static readonly DependencyProperty BerryColor =
+            DependencyProperty.Register("BerryColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        
+        public string CaughtColor
+        {
+            get { return (string)GetValue(CaughtColor); }
+            set { SetValue(CaughtColor, value); }
+        }
+        public static readonly DependencyProperty CaughtColor =
+            DependencyProperty.Register("CaughtColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+        
+        public string FleeColor
+        {
+            get { return (string)GetValue(FleeColor); }
+            set { SetValue(FleeColor, value); }
+        }
+        public static readonly DependencyProperty FleeColor =
+            DependencyProperty.Register("FleeColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string TransferColor
+        {
+            get { return (string)GetValue(TransferColor); }
+            set { SetValue(TransferColor, value); }
+        }
+        public static readonly DependencyProperty TransferColor =
+            DependencyProperty.Register("TransferColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string EvolveColor
+        {
+            get { return (string)GetValue(EvolveColor); }
+            set { SetValue(EvolveColor, value); }
+        }
+        public static readonly DependencyProperty EvolveColor =
+            DependencyProperty.Register("EvolveColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string EggColor
+        {
+            get { return (string)GetValue(EggColor); }
+            set { SetValue(EggColor, value); }
+        }
+        public static readonly DependencyProperty EggColor =
+            DependencyProperty.Register("EggColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string UpdateColor
+        {
+            get { return (string)GetValue(UpdateColor); }
+            set { SetValue(UpdateColor, value); }
+        }
+        public static readonly DependencyProperty UpdateColor =
+            DependencyProperty.Register("UpdateColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string InfoColor
+        {
+            get { return (string)GetValue(InfoColor); }
+            set { SetValue(InfoColor, value); }
+        }
+        public static readonly DependencyProperty InfoColor =
+            DependencyProperty.Register("InfoColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string NewColor
+        {
+            get { return (string)GetValue(NewColor); }
+            set { SetValue(NewColor, value); }
+        }
+        public static readonly DependencyProperty NewColor =
+            DependencyProperty.Register("NewColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string SoftBanColor
+        {
+            get { return (string)GetValue(SoftBanColor); }
+            set { SetValue(SoftBanColor, value); }
+        }
+        public static readonly DependencyProperty SoftBanColor =
+            DependencyProperty.Register("SoftBanColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string LevelUpColor
+        {
+            get { return (string)GetValue(LevelUpColor); }
+            set { SetValue(LevelUpColor, value); }
+        }
+        public static readonly DependencyProperty LevelUpColor =
+            DependencyProperty.Register("LevelUpColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
+                
+        public string DebugColor
+        {
+            get { return (string)GetValue(DebugColor); }
+            set { SetValue(DebugColor, value); }
+        }
+        public static readonly DependencyProperty DebugColor =
+            DependencyProperty.Register("DebugColor", typeof(string), typeof(ObservableSettings), new PropertyMetadata(string.Empty));
         #endregion MISC Properties
 
 

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -60,7 +60,17 @@ namespace PoGo.NecroBot.Logic
                         : moves ?? new List<List<PokemonMove>>();
             MovesOperator = movesOperator;
         }
-        
+        public int KeepMinCp { get; set; }
+        public int KeepMinLvl { get; set; }
+        public bool UseKeepMinLvl { get; set; }
+        public float KeepMinIvPercentage { get; set; }
+        public int KeepMinDuplicatePokemon { get; set; }
+        public List<List<PokemonMove>> Moves { get; set; }
+        public List<PokemonMove> DeprecatedMoves { get; set; }
+        public string KeepMinOperator { get; set; }
+        public string MovesOperator { get; set; }
+    }
+    
     public class Misc
     {
         public Misc()
@@ -86,18 +96,7 @@ namespace PoGo.NecroBot.Logic
         public string LevelUpColor { get; set; }
         public string DebugColor { get; set; }
     }
-
-        public int KeepMinCp { get; set; }
-        public int KeepMinLvl { get; set; }
-        public bool UseKeepMinLvl { get; set; }
-        public float KeepMinIvPercentage { get; set; }
-        public int KeepMinDuplicatePokemon { get; set; }
-        public List<List<PokemonMove>> Moves { get; set; }
-        public List<PokemonMove> DeprecatedMoves { get; set; }
-        public string KeepMinOperator { get; set; }
-        public string MovesOperator { get; set; }
-    }
-
+    
     public interface ILogicSettings
     {
         bool UseWebsocket { get; }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -60,6 +60,32 @@ namespace PoGo.NecroBot.Logic
                         : moves ?? new List<List<PokemonMove>>();
             MovesOperator = movesOperator;
         }
+        
+    public class Misc
+    {
+        public Misc()
+        {
+        }
+        
+        public string ErrorColor { get; set; }
+        public string WarningColor { get; set; }
+        public string PokestopColor { get; set; }
+        public string FarmingColor { get; set; }
+        public string SniperColor { get; set; }
+        public string RecyclingColor { get; set; }
+        public string BerryColor { get; set; }
+        public string CaughtColor { get; set; }
+        public string FleeColor { get; set; }
+        public string TransferColor { get; set; }
+        public string EvolveColor { get; set; }
+        public string EggColor { get; set; }
+        public string UpdateColor { get; set; }
+        public string InfoColor { get; set; }
+        public string NewColor { get; set; }
+        public string SoftBanColor { get; set; }
+        public string LevelUpColor { get; set; }
+        public string DebugColor { get; set; }
+    }
 
         public int KeepMinCp { get; set; }
         public int KeepMinLvl { get; set; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -525,6 +525,43 @@ namespace PoGo.NecroBot.Logic
         public bool UsePokemonToNotCatchFilter;
         [DefaultValue(false)]
         public bool UsePokemonSniperFilterOnly;
+        //log colors
+        [DefaultValue("Red")]
+        public string ErrorColor;
+        [DefaultValue("DarkYellow")]
+        public string WarningColor;
+        [DefaultValue("Cyan")]
+        public string PokestopColor;
+        [DefaultValue("Magenta")]
+        public string FarmingColor;
+        [DefaultValue("White")]
+        public string SniperColor;
+        [DefaultValue("DarkMagenta")]
+        public string RecyclingColor;
+        [DefaultValue("DarkYellow")]
+        public string BerryColor;
+        [DefaultValue("Green")]
+        public string CaughtColor;
+        [DefaultValue("DarkYellow")]
+        public string FleeColor;
+        [DefaultValue("DarkGreen")]
+        public string TransferColor;
+        [DefaultValue("DarkGreen")]
+        public string EvolveColor;
+        [DefaultValue("DarkYellow")]
+        public string EggColor;
+        [DefaultValue("White")]
+        public string UpdateColor;
+        [DefaultValue("DarkCyan")]
+        public string InfoColor;
+        [DefaultValue("Green")]
+        public string NewColor;
+        [DefaultValue("Red")]
+        public string SoftBanColor;
+        [DefaultValue("Magenta")]
+        public string LevelUpColor;
+        [DefaultValue("Gray")]
+        public string DebugColor;
 
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
         {
@@ -1448,5 +1485,24 @@ namespace PoGo.NecroBot.Logic
         public int TotalAmountOfPotionsToKeep => _settings.TotalAmountOfPotionsToKeep;
         public int TotalAmountOfRevivesToKeep => _settings.TotalAmountOfRevivesToKeep;
         public int TotalAmountOfBerriesToKeep => _settings.TotalAmountOfBerriesToKeep;
+        
+        public string ErrorColor => _settings.ErrorColor;
+        public string WarningColor => _settings.WarningColor;
+        public string PokestopColor => _settings.PokestopColor;
+        public string FarmingColor => _settings.FarmingColor;
+        public string SniperColor => _settings.SniperColor;
+        public string RecyclingColor => _settings.RecyclingColor;
+        public string BerryColor => _settings.BerryColor;
+        public string CaughtColor => _settings.CaughtColor;
+        public string FleeColor => _settings.FleeColor;
+        public string TransferColor => _settings.TransferColor;
+        public string EvolveColor => _settings.EvolveColor;
+        public string EggColor => _settings.EggColor;
+        public string UpdateColor => _settings.UpdateColor;
+        public string InfoColor => _settings.InfoColor;
+        public string NewColor => _settings.NewColor;
+        public string SoftBanColor => _settings.SoftBanColor;
+        public string LevelUpColor => _settings.LevelUpColor;
+        public string DebugColor => _settings.DebugColor;
     }
 }


### PR DESCRIPTION
Here are the defaults:

> 
{
"ErrorColor": "Red",
"WarningColor": "DarkYellow",
"PokestopColor": "Cyan",
"FarmingColor": "Magenta",
"SniperColor": "White",
"RecyclingColor": "DarkMagenta",
"BerryColor": "DarkYellow",
"CaughtColor": "Green",
"FleeColor": "DarkYellow",
"TransferColor": "DarkGreen",
"EvolveColor": "DarkGreen",
"EggColor": "DarkYellow",
"UpdateColor": "White",
"InfoColor": "DarkCyan",
"NewColor": "Green",
"SoftBanColor": "Red",
"LevelUpColor": "Magenta",
"DebugColor": "Gray"
}