### PR TITLE
Fixed Building Warning Message

### DIFF
--- a/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
+++ b/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
@@ -29,6 +29,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -29,7 +29,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>PoGo.NecroBot.Logic</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>PoGo.NecroBot.Logic</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190. ..\..\Program Files (x86)\MSBuild\14.0\bin\Microsoft.Common.CurrentVersion.targets 1820 5 PoGo.NecroBot.CLI

[405f8b9](https://ci.appveyor.com/project/NecronomiconCoding/necrobot-xyvdm/build/0.5.1409/messages)
PoGo.NecroBot.Logic
PoGo.NecroBot.CLI
[78b9c3b](https://ci.appveyor.com/project/NecronomiconCoding/necrobot-xyvdm/build/0.5.1410/messages)
PoGo.NecroBot.CLI
[8fcb33b](https://ci.appveyor.com/project/NecronomiconCoding/necrobot-xyvdm/build/0.5.1411/messages)
PoGo.NecroBot.CLI
[fde90b9](https://ci.appveyor.com/project/NecronomiconCoding/necrobot-xyvdm/build/0.5.1412/messages)
None